### PR TITLE
feat(cli): add version subcommand and basic CLI scaffolding

### DIFF
--- a/bin/turbolite.rs
+++ b/bin/turbolite.rs
@@ -7,8 +7,31 @@
 //! This binary is a placeholder for future CLI commands operating on the
 //! TurboliteVfs manifest + page group format.
 
+use clap::{CommandFactory, Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "turbolite", version, about = "turbolite CLI")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Version,
+}
+
 fn main() {
-    eprintln!("turbolite CLI: no commands implemented yet.");
-    eprintln!("The legacy CompressedVfs commands were removed in Phase Unification-h.");
-    std::process::exit(1);
+    let cli = Cli::parse();
+
+    match cli.command {
+        Some(Commands::Version) => {
+            println!("turbolite {}", env!("CARGO_PKG_VERSION"));
+        }
+        None => {
+            let mut command = Cli::command();
+            command.print_help().expect("failed to print help");
+            println!();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

The `turbolite` binary was a 12-line placeholder that exited with an error on every invocation. Its own source comment flagged it as awaiting future CLI commands:

> This binary is a placeholder for future CLI commands operating on the TurboliteVfs manifest + page group format.

This PR replaces the placeholder with minimal clap-based scaffolding so the binary is at least useful for querying the version, and future commands have an obvious place to land.

## Changes

`bin/turbolite.rs`:
- Adds a `version` subcommand that prints `turbolite {CARGO_PKG_VERSION}`
- Wires up `-V` / `--version` via clap's `#[command(version)]` attribute
- Wires up `-h` / `--help` (clap auto-generated)
- Running with no args now prints help and exits 0 (previously exited 1)

No new dependencies. `clap = { version = "4", features = ["derive", "env"] }` is already in `Cargo.toml`.

## Verification

Built and ran locally against a checkout of `main`:

```
$ cargo run --bin turbolite -- version
turbolite 0.3.0

$ cargo run --bin turbolite -- --version
turbolite 0.3.0

$ cargo run --bin turbolite -- --help
turbolite CLI

Usage: turbolite [COMMAND]

Commands:
  version
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version

$ cargo run --bin turbolite
turbolite CLI

Usage: turbolite [COMMAND]
...
$ echo $?
0
```

`cargo fmt --check bin/turbolite.rs` passes.

## Scope

Deliberately minimal. Does not touch the VFS, manifest, or page group code. Future commands (info, migrate, etc.) can slot into the existing `Commands` enum without further scaffolding work.

This contribution was developed with AI assistance (Codex).