### PR TITLE
Phase Mercury: CLI for managing turbolite databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 (Formerly `sqlite-compress-encrypt-vfs`, aka `sqlces`)
 
+## Mercury: CLI
+
+Replace placeholder CLI binary with management commands for turbolite databases.
+
+### Commands
+- `info` -- manifest summary: page count, groups, B-trees, storage type, seekable frames
+- `shell` -- interactive SQLite REPL through turbolite VFS (.tables, .schema, .quit)
+- `import` -- bulk import plain SQLite to turbolite S3 format (B-tree-aware grouping, seekable zstd)
+- `export` -- backup to plain SQLite via SQLite backup API
+- `download` -- pull entire database from S3 into local cache
+
+### Tests
+- 11 local integration tests (invoke compiled binary, check output/exit codes)
+- 2 Tigris S3 integration tests: import->info->export roundtrip with data verification, shell query against S3-backed database
+
+---
+
 ## Pelican: Lock-Free Architecture + Concurrent Performance
 
 Comprehensive performance overhaul: lock-free reads, mmap WAL-index, in-memory page

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rusqlite = { version = "0.35", optional = true }
+rusqlite = { version = "0.35", features = ["backup"], optional = true }
 libsqlite3-sys = { version = "0.33", features = ["bundled"], optional = true }
 tempfile = "3"
 ureq = "2"

--- a/README.md
+++ b/README.md
@@ -477,12 +477,6 @@ turbolite info --db my.db --bucket my-bucket --endpoint https://t3.storage.dev
 turbolite shell --db my.db
 turbolite shell --db my.db --bucket my-bucket --read-only
 
-# Garbage collection (delete orphaned S3 objects)
-turbolite gc --db my.db --bucket my-bucket
-
-# Force checkpoint + S3 upload
-turbolite checkpoint --db my.db --bucket my-bucket
-
 # Download entire database from S3 into local cache
 turbolite download --db my.db --bucket my-bucket --threads 8
 

--- a/README.md
+++ b/README.md
@@ -483,8 +483,8 @@ turbolite gc --db my.db --bucket my-bucket
 # Force checkpoint + S3 upload
 turbolite checkpoint --db my.db --bucket my-bucket
 
-# Warm local cache by fetching all page groups
-turbolite prefetch --db my.db --bucket my-bucket --threads 8
+# Download entire database from S3 into local cache
+turbolite download --db my.db --bucket my-bucket --threads 8
 
 # Export to plain SQLite (for migration or backup)
 turbolite export --db my.db --output plain.db

--- a/README.md
+++ b/README.md
@@ -458,6 +458,43 @@ let conn = rusqlite::Connection::open_with_flags_and_vfs(
 )?;
 ```
 
+## CLI
+
+turbolite ships a CLI for inspecting, managing, and interacting with turbolite databases without writing Rust.
+
+```bash
+cargo install turbolite --features cloud,zstd
+```
+
+### Commands
+
+```bash
+# Inspect a database manifest
+turbolite info --db my.db
+turbolite info --db my.db --bucket my-bucket --endpoint https://t3.storage.dev
+
+# Interactive SQLite shell (with turbolite VFS)
+turbolite shell --db my.db
+turbolite shell --db my.db --bucket my-bucket --read-only
+
+# Garbage collection (delete orphaned S3 objects)
+turbolite gc --db my.db --bucket my-bucket
+
+# Force checkpoint + S3 upload
+turbolite checkpoint --db my.db --bucket my-bucket
+
+# Warm local cache by fetching all page groups
+turbolite prefetch --db my.db --bucket my-bucket --threads 8
+
+# Export to plain SQLite (for migration or backup)
+turbolite export --db my.db --output plain.db
+
+# Import a plain SQLite file into turbolite S3 format
+turbolite import --input plain.db --bucket my-bucket --prefix databases/my-db
+```
+
+All S3 commands accept `--bucket`, `--prefix`, `--endpoint`, and `--region` flags, or read from `TURBOLITE_BUCKET`, `TURBOLITE_PREFIX`, `AWS_ENDPOINT_URL`, and `AWS_REGION` environment variables.
+
 ## Related Projects and Comparison
 
 There are many projects in the SQLite-over-network space. turbolite borrows ideas from all of them.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,41 @@
 # turbolite Roadmap
 
+## Mercury: CLI
+> After: Pelican (CHANGELOG) · Before: Soyuz
+
+Replace the placeholder CLI binary with a useful command-line tool for inspecting,
+managing, and interacting with turbolite databases. Currently the only way to GC,
+import, export, or inspect a manifest is through the Rust API. A CLI makes turbolite
+usable by operators and scripts without writing Rust.
+
+### a. Core commands (high value)
+- [ ] `turbolite info <db>` -- print manifest summary: page count, group count, compression ratio, S3 size vs uncompressed, storage backend, last checkpoint. The "is my database healthy?" command.
+- [ ] `turbolite shell <db>` -- open an interactive SQLite REPL on a turbolite database (register VFS, open connection, readline loop). Saves users from manually wiring up the VFS.
+- [ ] `turbolite gc <db>` -- run garbage collection on old page group versions. Currently only available via Rust API.
+
+### b. Operations commands (medium value)
+- [ ] `turbolite checkpoint <db>` -- force checkpoint + S3 upload. Useful for cron jobs or pre-shutdown scripts.
+- [ ] `turbolite prefetch <db>` -- warm the local cache by fetching all page groups from S3. "I'm about to get traffic, pre-warm this database."
+- [ ] `turbolite export <db> <path>` -- materialize a turbolite database into a plain SQLite file (decompress, decrypt, write sequential pages). For migration or backup.
+- [ ] `turbolite import <path> <db>` -- take a plain SQLite file and chunk it into turbolite format in S3. Onboarding path.
+
+### c. Nice to have
+- [ ] `turbolite dict train <db>` -- train a zstd dictionary from a database's pages. Currently only in the bench binary.
+- [ ] `turbolite keys rotate <db>` -- encryption key rotation from CLI instead of Rust API.
+- [ ] `turbolite bench` -- move tiered-bench into CLI subcommand.
+
+### d. Tests
+- [ ] Integration tests for each command (invoke binary, check output/exit code)
+- [ ] `info` on local and S3 databases, empty database, corrupted manifest
+- [ ] `shell` executes SQL and returns results
+- [ ] `gc` removes old versions, idempotent on clean database
+- [ ] `export` produces valid SQLite file, `import` round-trips with `export`
+- [ ] `checkpoint` forces upload, `prefetch` warms cache
+
+---
+
 ## Soyuz: Migrate from sqlite-vfs to sqlite-plugin
-> After: Pelican (CHANGELOG) · Before: Valkyrie
+> After: Mercury · Before: Valkyrie
 
 Replace `sqlite-vfs` (rkusa, unmaintained since 2022, self-described prototype) with
 `sqlite-plugin` (orbitinghail/Carl Sverre, active, used by Graft).
@@ -276,12 +310,6 @@ Value partitions are read-only, built at import. Handle staleness gracefully.
 - [ ] `madvise(MADV_RANDOM)`
 - [ ] Handle cache file growth: `mremap` on Linux, re-map on macOS
 - [ ] Benchmark: warm lookup latency mmap vs pread (expect ~10-50us to ~1-5us)
-
-### CLI subcommands
-- [ ] `turbolite bench` -- move tiered-bench into CLI subcommand
-- [ ] `turbolite gc --bucket X --prefix Y` -- one-shot GC
-- [ ] `turbolite import --bucket X --prefix Y --db local.db`
-- [ ] `turbolite info --bucket X --prefix Y` -- print manifest summary
 
 ### Bidirectional prefetch
 - Track access direction, prefetch backward for DESC queries

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ usable by operators and scripts without writing Rust.
 
 ### b. Operations commands (medium value)
 - [ ] `turbolite checkpoint <db>` -- force checkpoint + S3 upload. Useful for cron jobs or pre-shutdown scripts.
-- [ ] `turbolite prefetch <db>` -- warm the local cache by fetching all page groups from S3. "I'm about to get traffic, pre-warm this database."
+- [ ] `turbolite download <db>` -- download the entire database from S3 into local cache.
 - [ ] `turbolite export <db> <path>` -- materialize a turbolite database into a plain SQLite file (decompress, decrypt, write sequential pages). For migration or backup.
 - [ ] `turbolite import <path> <db>` -- take a plain SQLite file and chunk it into turbolite format in S3. Onboarding path.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,41 +1,7 @@
 # turbolite Roadmap
 
-## Mercury: CLI
-> After: Pelican (CHANGELOG) · Before: Soyuz
-
-Replace the placeholder CLI binary with a useful command-line tool for inspecting,
-managing, and interacting with turbolite databases. Currently the only way to GC,
-import, export, or inspect a manifest is through the Rust API. A CLI makes turbolite
-usable by operators and scripts without writing Rust.
-
-### a. Core commands (high value)
-- [ ] `turbolite info <db>` -- print manifest summary: page count, group count, compression ratio, S3 size vs uncompressed, storage backend, last checkpoint. The "is my database healthy?" command.
-- [ ] `turbolite shell <db>` -- open an interactive SQLite REPL on a turbolite database (register VFS, open connection, readline loop). Saves users from manually wiring up the VFS.
-- [ ] `turbolite gc <db>` -- run garbage collection on old page group versions. Currently only available via Rust API.
-
-### b. Operations commands (medium value)
-- [ ] `turbolite checkpoint <db>` -- force checkpoint + S3 upload. Useful for cron jobs or pre-shutdown scripts.
-- [ ] `turbolite download <db>` -- download the entire database from S3 into local cache.
-- [ ] `turbolite export <db> <path>` -- materialize a turbolite database into a plain SQLite file (decompress, decrypt, write sequential pages). For migration or backup.
-- [ ] `turbolite import <path> <db>` -- take a plain SQLite file and chunk it into turbolite format in S3. Onboarding path.
-
-### c. Nice to have
-- [ ] `turbolite dict train <db>` -- train a zstd dictionary from a database's pages. Currently only in the bench binary.
-- [ ] `turbolite keys rotate <db>` -- encryption key rotation from CLI instead of Rust API.
-- [ ] `turbolite bench` -- move tiered-bench into CLI subcommand.
-
-### d. Tests
-- [ ] Integration tests for each command (invoke binary, check output/exit code)
-- [ ] `info` on local and S3 databases, empty database, corrupted manifest
-- [ ] `shell` executes SQL and returns results
-- [ ] `gc` removes old versions, idempotent on clean database
-- [ ] `export` produces valid SQLite file, `import` round-trips with `export`
-- [ ] `checkpoint` forces upload, `prefetch` warms cache
-
----
-
 ## Soyuz: Migrate from sqlite-vfs to sqlite-plugin
-> After: Mercury · Before: Valkyrie
+> After: Mercury (CHANGELOG) · Before: Valkyrie
 
 Replace `sqlite-vfs` (rkusa, unmaintained since 2022, self-described prototype) with
 `sqlite-plugin` (orbitinghail/Carl Sverre, active, used by Graft).

--- a/bin/turbolite.rs
+++ b/bin/turbolite.rs
@@ -133,8 +133,8 @@ enum Commands {
         cache_dir: PathBuf,
     },
 
-    /// Warm the local cache by fetching all page groups from S3
-    Prefetch {
+    /// Download the entire database from S3 into local cache
+    Download {
         /// Path to the database file
         #[arg(long)]
         db: PathBuf,
@@ -562,7 +562,7 @@ fn cmd_checkpoint(
     Ok(())
 }
 
-fn cmd_prefetch(
+fn cmd_download(
     db: PathBuf,
     bucket: String,
     prefix: Option<String>,
@@ -574,14 +574,14 @@ fn cmd_prefetch(
     let mut config = build_config(cache_dir, Some(bucket), prefix, endpoint, region, true);
     config.prefetch_threads = threads;
 
-    let vfs_name = format!("turbolite-prefetch-{}", std::process::id());
+    let vfs_name = format!("turbolite-download-{}", std::process::id());
     let (shared, conn) = open_shared(&db, config, &vfs_name)?;
 
     let manifest = shared.manifest();
     let total_groups = manifest.page_group_keys.len();
 
-    // Connection open already fetches interior + index pages eagerly.
-    // Now scan every table to pull all data pages into the local cache.
+    // Connection open fetches interior + index pages eagerly.
+    // Full table scans pull all remaining data pages into local cache.
     let tables: Vec<String> = {
         let mut stmt = conn
             .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
@@ -593,7 +593,6 @@ fn cmd_prefetch(
     };
 
     for table in &tables {
-        // Full scan triggers prefetch of all data page groups for this table
         let sql = format!("SELECT COUNT(*) FROM \"{}\"", table.replace('"', "\"\""));
         let _: i64 = conn
             .query_row(&sql, [], |row| row.get(0))
@@ -602,7 +601,7 @@ fn cmd_prefetch(
 
     let (fetches, bytes) = shared.s3_counters();
     println!(
-        "prefetch: {} tables, {} groups, {} S3 GETs, {:.1} MB fetched",
+        "download: {} tables, {} groups, {} S3 GETs, {:.1} MB",
         tables.len(),
         total_groups,
         fetches,
@@ -726,8 +725,8 @@ fn main() -> Result<()> {
         Commands::Checkpoint { db, bucket, prefix, endpoint, region, cache_dir } => {
             cmd_checkpoint(db, bucket, prefix, endpoint, region, cache_dir)?;
         }
-        Commands::Prefetch { db, bucket, prefix, endpoint, region, cache_dir, threads } => {
-            cmd_prefetch(db, bucket, prefix, endpoint, region, cache_dir, threads)?;
+        Commands::Download { db, bucket, prefix, endpoint, region, cache_dir, threads } => {
+            cmd_download(db, bucket, prefix, endpoint, region, cache_dir, threads)?;
         }
         Commands::Export { db, output, bucket, prefix, endpoint, region, cache_dir } => {
             cmd_export(db, output, bucket, prefix, endpoint, region, cache_dir)?;

--- a/bin/turbolite.rs
+++ b/bin/turbolite.rs
@@ -1,7 +1,7 @@
 //! turbolite CLI
 //!
-//! Management commands for turbolite databases: inspect manifests, run GC,
-//! import/export, interactive shell, cache warming, and more.
+//! Management commands for turbolite databases: inspect manifests,
+//! import/export, interactive shell, and cache download.
 
 use std::io::{self, BufRead, Write as _};
 use std::path::PathBuf;
@@ -18,9 +18,6 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Print version
-    Version,
-
     /// Print manifest summary for a turbolite database
     Info {
         /// Path to the database file
@@ -77,60 +74,6 @@ enum Commands {
         /// Open in read-only mode
         #[arg(long)]
         read_only: bool,
-    },
-
-    /// Run garbage collection on old S3 page group versions
-    Gc {
-        /// Path to the database file
-        #[arg(long)]
-        db: PathBuf,
-
-        /// S3 bucket (required, or set TURBOLITE_BUCKET)
-        #[arg(long, env = "TURBOLITE_BUCKET")]
-        bucket: String,
-
-        /// S3 key prefix (or set TURBOLITE_PREFIX)
-        #[arg(long, env = "TURBOLITE_PREFIX")]
-        prefix: Option<String>,
-
-        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
-        #[arg(long, env = "AWS_ENDPOINT_URL")]
-        endpoint: Option<String>,
-
-        /// AWS region (or set AWS_REGION)
-        #[arg(long, env = "AWS_REGION")]
-        region: Option<String>,
-
-        /// Local cache directory
-        #[arg(long, default_value = "/tmp/turbolite-cache")]
-        cache_dir: PathBuf,
-    },
-
-    /// Force a checkpoint and S3 upload
-    Checkpoint {
-        /// Path to the database file
-        #[arg(long)]
-        db: PathBuf,
-
-        /// S3 bucket (required, or set TURBOLITE_BUCKET)
-        #[arg(long, env = "TURBOLITE_BUCKET")]
-        bucket: String,
-
-        /// S3 key prefix (or set TURBOLITE_PREFIX)
-        #[arg(long, env = "TURBOLITE_PREFIX")]
-        prefix: Option<String>,
-
-        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
-        #[arg(long, env = "AWS_ENDPOINT_URL")]
-        endpoint: Option<String>,
-
-        /// AWS region (or set AWS_REGION)
-        #[arg(long, env = "AWS_REGION")]
-        region: Option<String>,
-
-        /// Local cache directory
-        #[arg(long, default_value = "/tmp/turbolite-cache")]
-        cache_dir: PathBuf,
     },
 
     /// Download the entire database from S3 into local cache
@@ -518,50 +461,6 @@ fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
-fn cmd_gc(
-    db: PathBuf,
-    bucket: String,
-    prefix: Option<String>,
-    endpoint: Option<String>,
-    region: Option<String>,
-    cache_dir: PathBuf,
-) -> Result<()> {
-    let config = build_config(cache_dir, Some(bucket), prefix, endpoint, region, false);
-    let vfs_name = format!("turbolite-gc-{}", std::process::id());
-    let (shared, _conn) = open_shared(&db, config, &vfs_name)?;
-
-    let deleted = shared.gc()
-        .map_err(|e| anyhow!("gc failed: {}", e))?;
-
-    if deleted > 0 {
-        println!("gc: deleted {} orphaned S3 objects", deleted);
-    } else {
-        println!("gc: no orphaned objects found");
-    }
-
-    Ok(())
-}
-
-fn cmd_checkpoint(
-    db: PathBuf,
-    bucket: String,
-    prefix: Option<String>,
-    endpoint: Option<String>,
-    region: Option<String>,
-    cache_dir: PathBuf,
-) -> Result<()> {
-    let config = build_config(cache_dir, Some(bucket), prefix, endpoint, region, false);
-    let vfs_name = format!("turbolite-ckpt-{}", std::process::id());
-    let (_shared, conn) = open_shared(&db, config, &vfs_name)?;
-
-    // Force a WAL checkpoint (TRUNCATE mode flushes all WAL frames and resets the WAL)
-    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
-        .context("checkpoint failed")?;
-
-    println!("checkpoint: complete");
-    Ok(())
-}
-
 fn cmd_download(
     db: PathBuf,
     bucket: String,
@@ -710,20 +609,11 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Version => {
-            println!("turbolite {}", env!("CARGO_PKG_VERSION"));
-        }
         Commands::Info { db, bucket, prefix, endpoint, region, cache_dir } => {
             cmd_info(db, bucket, prefix, endpoint, region, cache_dir)?;
         }
         Commands::Shell { db, bucket, prefix, endpoint, region, cache_dir, read_only } => {
             cmd_shell(db, bucket, prefix, endpoint, region, cache_dir, read_only)?;
-        }
-        Commands::Gc { db, bucket, prefix, endpoint, region, cache_dir } => {
-            cmd_gc(db, bucket, prefix, endpoint, region, cache_dir)?;
-        }
-        Commands::Checkpoint { db, bucket, prefix, endpoint, region, cache_dir } => {
-            cmd_checkpoint(db, bucket, prefix, endpoint, region, cache_dir)?;
         }
         Commands::Download { db, bucket, prefix, endpoint, region, cache_dir, threads } => {
             cmd_download(db, bucket, prefix, endpoint, region, cache_dir, threads)?;

--- a/bin/turbolite.rs
+++ b/bin/turbolite.rs
@@ -1,37 +1,748 @@
 //! turbolite CLI
 //!
-//! The legacy CompressedVfs management commands (info, compact, convert, encrypt,
-//! decrypt, embed-dict, extract-dict) have been removed along with the CompressedVfs
-//! format. Use TurboliteVfs local mode instead.
-//!
-//! This binary is a placeholder for future CLI commands operating on the
-//! TurboliteVfs manifest + page group format.
+//! Management commands for turbolite databases: inspect manifests, run GC,
+//! import/export, interactive shell, cache warming, and more.
 
-use clap::{CommandFactory, Parser, Subcommand};
+use std::io::{self, BufRead, Write as _};
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(name = "turbolite", version, about = "turbolite CLI")]
 struct Cli {
     #[command(subcommand)]
-    command: Option<Commands>,
+    command: Commands,
 }
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Print version
     Version,
+
+    /// Print manifest summary for a turbolite database
+    Info {
+        /// Path to the database file
+        #[arg(long)]
+        db: PathBuf,
+
+        /// S3 bucket (or set TURBOLITE_BUCKET)
+        #[arg(long, env = "TURBOLITE_BUCKET")]
+        bucket: Option<String>,
+
+        /// S3 key prefix (or set TURBOLITE_PREFIX)
+        #[arg(long, env = "TURBOLITE_PREFIX")]
+        prefix: Option<String>,
+
+        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
+        #[arg(long, env = "AWS_ENDPOINT_URL")]
+        endpoint: Option<String>,
+
+        /// AWS region (or set AWS_REGION)
+        #[arg(long, env = "AWS_REGION")]
+        region: Option<String>,
+
+        /// Local cache directory
+        #[arg(long, default_value = "/tmp/turbolite-cache")]
+        cache_dir: PathBuf,
+    },
+
+    /// Open an interactive SQLite shell on a turbolite database
+    Shell {
+        /// Path to the database file
+        #[arg(long)]
+        db: PathBuf,
+
+        /// S3 bucket (or set TURBOLITE_BUCKET)
+        #[arg(long, env = "TURBOLITE_BUCKET")]
+        bucket: Option<String>,
+
+        /// S3 key prefix (or set TURBOLITE_PREFIX)
+        #[arg(long, env = "TURBOLITE_PREFIX")]
+        prefix: Option<String>,
+
+        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
+        #[arg(long, env = "AWS_ENDPOINT_URL")]
+        endpoint: Option<String>,
+
+        /// AWS region (or set AWS_REGION)
+        #[arg(long, env = "AWS_REGION")]
+        region: Option<String>,
+
+        /// Local cache directory
+        #[arg(long, default_value = "/tmp/turbolite-cache")]
+        cache_dir: PathBuf,
+
+        /// Open in read-only mode
+        #[arg(long)]
+        read_only: bool,
+    },
+
+    /// Run garbage collection on old S3 page group versions
+    Gc {
+        /// Path to the database file
+        #[arg(long)]
+        db: PathBuf,
+
+        /// S3 bucket (required, or set TURBOLITE_BUCKET)
+        #[arg(long, env = "TURBOLITE_BUCKET")]
+        bucket: String,
+
+        /// S3 key prefix (or set TURBOLITE_PREFIX)
+        #[arg(long, env = "TURBOLITE_PREFIX")]
+        prefix: Option<String>,
+
+        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
+        #[arg(long, env = "AWS_ENDPOINT_URL")]
+        endpoint: Option<String>,
+
+        /// AWS region (or set AWS_REGION)
+        #[arg(long, env = "AWS_REGION")]
+        region: Option<String>,
+
+        /// Local cache directory
+        #[arg(long, default_value = "/tmp/turbolite-cache")]
+        cache_dir: PathBuf,
+    },
+
+    /// Force a checkpoint and S3 upload
+    Checkpoint {
+        /// Path to the database file
+        #[arg(long)]
+        db: PathBuf,
+
+        /// S3 bucket (required, or set TURBOLITE_BUCKET)
+        #[arg(long, env = "TURBOLITE_BUCKET")]
+        bucket: String,
+
+        /// S3 key prefix (or set TURBOLITE_PREFIX)
+        #[arg(long, env = "TURBOLITE_PREFIX")]
+        prefix: Option<String>,
+
+        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
+        #[arg(long, env = "AWS_ENDPOINT_URL")]
+        endpoint: Option<String>,
+
+        /// AWS region (or set AWS_REGION)
+        #[arg(long, env = "AWS_REGION")]
+        region: Option<String>,
+
+        /// Local cache directory
+        #[arg(long, default_value = "/tmp/turbolite-cache")]
+        cache_dir: PathBuf,
+    },
+
+    /// Warm the local cache by fetching all page groups from S3
+    Prefetch {
+        /// Path to the database file
+        #[arg(long)]
+        db: PathBuf,
+
+        /// S3 bucket (required, or set TURBOLITE_BUCKET)
+        #[arg(long, env = "TURBOLITE_BUCKET")]
+        bucket: String,
+
+        /// S3 key prefix (or set TURBOLITE_PREFIX)
+        #[arg(long, env = "TURBOLITE_PREFIX")]
+        prefix: Option<String>,
+
+        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
+        #[arg(long, env = "AWS_ENDPOINT_URL")]
+        endpoint: Option<String>,
+
+        /// AWS region (or set AWS_REGION)
+        #[arg(long, env = "AWS_REGION")]
+        region: Option<String>,
+
+        /// Local cache directory
+        #[arg(long, default_value = "/tmp/turbolite-cache")]
+        cache_dir: PathBuf,
+
+        /// Number of prefetch threads
+        #[arg(long, default_value = "8")]
+        threads: u32,
+    },
+
+    /// Export a turbolite database to a plain SQLite file
+    Export {
+        /// Path to the turbolite database
+        #[arg(long)]
+        db: PathBuf,
+
+        /// Output path for the plain SQLite file
+        #[arg(long)]
+        output: PathBuf,
+
+        /// S3 bucket (or set TURBOLITE_BUCKET)
+        #[arg(long, env = "TURBOLITE_BUCKET")]
+        bucket: Option<String>,
+
+        /// S3 key prefix (or set TURBOLITE_PREFIX)
+        #[arg(long, env = "TURBOLITE_PREFIX")]
+        prefix: Option<String>,
+
+        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
+        #[arg(long, env = "AWS_ENDPOINT_URL")]
+        endpoint: Option<String>,
+
+        /// AWS region (or set AWS_REGION)
+        #[arg(long, env = "AWS_REGION")]
+        region: Option<String>,
+
+        /// Local cache directory
+        #[arg(long, default_value = "/tmp/turbolite-cache")]
+        cache_dir: PathBuf,
+    },
+
+    /// Import a plain SQLite file into turbolite S3 format
+    Import {
+        /// Path to the plain SQLite file to import
+        #[arg(long)]
+        input: PathBuf,
+
+        /// S3 bucket (required, or set TURBOLITE_BUCKET)
+        #[arg(long, env = "TURBOLITE_BUCKET")]
+        bucket: String,
+
+        /// S3 key prefix (or set TURBOLITE_PREFIX)
+        #[arg(long, env = "TURBOLITE_PREFIX")]
+        prefix: Option<String>,
+
+        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
+        #[arg(long, env = "AWS_ENDPOINT_URL")]
+        endpoint: Option<String>,
+
+        /// AWS region (or set AWS_REGION)
+        #[arg(long, env = "AWS_REGION")]
+        region: Option<String>,
+
+        /// Pages per group (default 256)
+        #[arg(long, default_value = "256")]
+        pages_per_group: u32,
+
+        /// Zstd compression level (1-22, default 3)
+        #[arg(long, default_value = "3")]
+        compression_level: i32,
+    },
 }
 
-fn main() {
+/// Build a TurboliteConfig from common CLI args.
+fn build_config(
+    cache_dir: PathBuf,
+    bucket: Option<String>,
+    prefix: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    read_only: bool,
+) -> turbolite::tiered::TurboliteConfig {
+    use turbolite::tiered::{StorageBackend, TurboliteConfig};
+
+    let storage_backend = match bucket {
+        Some(ref b) => StorageBackend::S3 {
+            bucket: b.clone(),
+            prefix: prefix.clone().unwrap_or_default(),
+            endpoint_url: endpoint.clone(),
+            region: region.clone(),
+        },
+        None => StorageBackend::Local,
+    };
+
+    TurboliteConfig {
+        storage_backend,
+        bucket: bucket.unwrap_or_default(),
+        prefix: prefix.unwrap_or_default(),
+        endpoint_url: endpoint,
+        region,
+        cache_dir,
+        read_only,
+        ..Default::default()
+    }
+}
+
+/// Register a VFS and open a rusqlite connection.
+fn open_connection(
+    db: &std::path::Path,
+    config: turbolite::tiered::TurboliteConfig,
+    vfs_name: &str,
+) -> Result<rusqlite::Connection> {
+    let vfs = turbolite::tiered::TurboliteVfs::new(config)
+        .context("failed to create VFS")?;
+    turbolite::tiered::register(vfs_name, vfs)
+        .context("failed to register VFS")?;
+
+    let flags = rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_CREATE;
+    let conn = rusqlite::Connection::open_with_flags_and_vfs(db, flags, vfs_name)
+        .context("failed to open database")?;
+    Ok(conn)
+}
+
+/// Register a shared VFS and return (SharedTurboliteVfs, Connection).
+fn open_shared(
+    db: &std::path::Path,
+    config: turbolite::tiered::TurboliteConfig,
+    vfs_name: &str,
+) -> Result<(turbolite::tiered::SharedTurboliteVfs, rusqlite::Connection)> {
+    let vfs = turbolite::tiered::TurboliteVfs::new(config)
+        .context("failed to create VFS")?;
+    let shared = turbolite::tiered::SharedTurboliteVfs::new(vfs);
+    turbolite::tiered::register_shared(vfs_name, shared.clone())
+        .context("failed to register shared VFS")?;
+
+    let flags = rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_CREATE;
+    let conn = rusqlite::Connection::open_with_flags_and_vfs(db, flags, vfs_name)
+        .context("failed to open database")?;
+    Ok((shared, conn))
+}
+
+fn cmd_info(
+    db: PathBuf,
+    bucket: Option<String>,
+    prefix: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    cache_dir: PathBuf,
+) -> Result<()> {
+    let config = build_config(cache_dir, bucket, prefix, endpoint, region, true);
+    let vfs_name = format!("turbolite-info-{}", std::process::id());
+    let vfs = turbolite::tiered::TurboliteVfs::new(config)
+        .context("failed to create VFS")?;
+    let shared = turbolite::tiered::SharedTurboliteVfs::new(vfs);
+    turbolite::tiered::register_shared(&vfs_name, shared.clone())
+        .context("failed to register VFS")?;
+
+    // Open connection to initialize VFS state
+    let flags = rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_CREATE;
+    let _conn = rusqlite::Connection::open_with_flags_and_vfs(&db, flags, &vfs_name)
+        .context("failed to open database")?;
+
+    let manifest = shared.manifest();
+
+    let total_groups = manifest.page_group_keys.len();
+    let interior_chunks = manifest.interior_chunk_keys.len();
+    let index_chunks = manifest.index_chunk_keys.len();
+    let page_count = manifest.page_count;
+    let page_size = manifest.page_size;
+    let uncompressed_bytes = page_count * page_size as u64;
+    let btree_count = manifest.btrees.len();
+
+    println!("turbolite database: {}", db.display());
+    println!();
+    println!("  manifest version:  {}", manifest.version);
+    println!("  change counter:    {}", manifest.change_counter);
+    println!("  storage:           {}", if shared.has_remote_storage() { "S3" } else { "local" });
+    println!("  strategy:          {:?}", manifest.strategy);
+    println!();
+    println!("  pages:             {}", page_count);
+    println!("  page size:         {} bytes", page_size);
+    println!("  uncompressed size: {:.1} MB", uncompressed_bytes as f64 / (1024.0 * 1024.0));
+    println!();
+    println!("  page groups:       {}", total_groups);
+    println!("  pages per group:   {}", manifest.pages_per_group);
+    println!("  interior chunks:   {}", interior_chunks);
+    println!("  index chunks:      {}", index_chunks);
+    println!("  B-trees:           {}", btree_count);
+
+    if manifest.sub_pages_per_frame > 0 {
+        println!("  seekable frames:   yes (sub_ppf={})", manifest.sub_pages_per_frame);
+    } else {
+        println!("  seekable frames:   no");
+    }
+
+    if !manifest.btrees.is_empty() {
+        println!();
+        println!("  B-tree summary:");
+        let mut entries: Vec<_> = manifest.btrees.iter().collect();
+        entries.sort_by_key(|(root, _)| *root);
+        for (root, entry) in entries {
+            println!(
+                "    root={:<6} type={:<8} name={:<30} groups={}",
+                root,
+                entry.obj_type,
+                entry.name,
+                entry.group_ids.len(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn cmd_shell(
+    db: PathBuf,
+    bucket: Option<String>,
+    prefix: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    cache_dir: PathBuf,
+    read_only: bool,
+) -> Result<()> {
+    let config = build_config(cache_dir, bucket, prefix, endpoint, region, read_only);
+    let vfs_name = format!("turbolite-shell-{}", std::process::id());
+    let conn = open_connection(&db, config, &vfs_name)?;
+
+    let mode_str = if read_only { " (read-only)" } else { "" };
+    println!("turbolite shell{} -- {}", mode_str, db.display());
+    println!("Type .quit to exit, .tables to list tables, .schema to show schema.");
+    println!();
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+
+    loop {
+        print!("turbolite> ");
+        stdout.lock().flush()?;
+
+        let mut line = String::new();
+        if stdin.lock().read_line(&mut line)? == 0 {
+            // EOF
+            println!();
+            break;
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match trimmed {
+            ".quit" | ".exit" => break,
+            ".tables" => {
+                let sql = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name";
+                match conn.prepare(sql) {
+                    Ok(mut stmt) => {
+                        let rows = stmt.query_map([], |row| row.get::<_, String>(0));
+                        match rows {
+                            Ok(rows) => {
+                                for row in rows {
+                                    match row {
+                                        Ok(name) => println!("{}", name),
+                                        Err(e) => eprintln!("Error: {}", e),
+                                    }
+                                }
+                            }
+                            Err(e) => eprintln!("Error: {}", e),
+                        }
+                    }
+                    Err(e) => eprintln!("Error: {}", e),
+                }
+            }
+            ".schema" => {
+                let sql = "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY type, name";
+                match conn.prepare(sql) {
+                    Ok(mut stmt) => {
+                        let rows = stmt.query_map([], |row| row.get::<_, String>(0));
+                        match rows {
+                            Ok(rows) => {
+                                for row in rows {
+                                    match row {
+                                        Ok(sql) => println!("{};", sql),
+                                        Err(e) => eprintln!("Error: {}", e),
+                                    }
+                                }
+                            }
+                            Err(e) => eprintln!("Error: {}", e),
+                        }
+                    }
+                    Err(e) => eprintln!("Error: {}", e),
+                }
+            }
+            _ => {
+                // Try as a query first (SELECT, EXPLAIN, PRAGMA, etc.)
+                let is_query = {
+                    let upper = trimmed.to_uppercase();
+                    upper.starts_with("SELECT")
+                        || upper.starts_with("EXPLAIN")
+                        || upper.starts_with("PRAGMA")
+                        || upper.starts_with("WITH")
+                };
+
+                if is_query {
+                    match conn.prepare(trimmed) {
+                        Ok(mut stmt) => {
+                            let col_count = stmt.column_count();
+                            let col_names: Vec<String> = (0..col_count)
+                                .map(|i| stmt.column_name(i).expect("column name").to_string())
+                                .collect();
+
+                            // Print header
+                            println!("{}", col_names.join("|"));
+
+                            match stmt.query_map([], |row| {
+                                let vals: Vec<String> = (0..col_count)
+                                    .map(|i| {
+                                        row.get::<_, rusqlite::types::Value>(i)
+                                            .map(|v| format_value(&v))
+                                            .unwrap_or_else(|_| "ERROR".to_string())
+                                    })
+                                    .collect();
+                                Ok(vals.join("|"))
+                            }) {
+                                Ok(rows) => {
+                                    for row in rows {
+                                        match row {
+                                            Ok(line) => println!("{}", line),
+                                            Err(e) => eprintln!("Error: {}", e),
+                                        }
+                                    }
+                                }
+                                Err(e) => eprintln!("Error: {}", e),
+                            }
+                        }
+                        Err(e) => eprintln!("Error: {}", e),
+                    }
+                } else {
+                    match conn.execute_batch(trimmed) {
+                        Ok(()) => {}
+                        Err(e) => eprintln!("Error: {}", e),
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn format_value(v: &rusqlite::types::Value) -> String {
+    match v {
+        rusqlite::types::Value::Null => "NULL".to_string(),
+        rusqlite::types::Value::Integer(i) => i.to_string(),
+        rusqlite::types::Value::Real(f) => f.to_string(),
+        rusqlite::types::Value::Text(s) => s.clone(),
+        rusqlite::types::Value::Blob(b) => format!("x'{}'", hex_encode(b)),
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn cmd_gc(
+    db: PathBuf,
+    bucket: String,
+    prefix: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    cache_dir: PathBuf,
+) -> Result<()> {
+    let config = build_config(cache_dir, Some(bucket), prefix, endpoint, region, false);
+    let vfs_name = format!("turbolite-gc-{}", std::process::id());
+    let (shared, _conn) = open_shared(&db, config, &vfs_name)?;
+
+    let deleted = shared.gc()
+        .map_err(|e| anyhow!("gc failed: {}", e))?;
+
+    if deleted > 0 {
+        println!("gc: deleted {} orphaned S3 objects", deleted);
+    } else {
+        println!("gc: no orphaned objects found");
+    }
+
+    Ok(())
+}
+
+fn cmd_checkpoint(
+    db: PathBuf,
+    bucket: String,
+    prefix: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    cache_dir: PathBuf,
+) -> Result<()> {
+    let config = build_config(cache_dir, Some(bucket), prefix, endpoint, region, false);
+    let vfs_name = format!("turbolite-ckpt-{}", std::process::id());
+    let (_shared, conn) = open_shared(&db, config, &vfs_name)?;
+
+    // Force a WAL checkpoint (TRUNCATE mode flushes all WAL frames and resets the WAL)
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+        .context("checkpoint failed")?;
+
+    println!("checkpoint: complete");
+    Ok(())
+}
+
+fn cmd_prefetch(
+    db: PathBuf,
+    bucket: String,
+    prefix: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    cache_dir: PathBuf,
+    threads: u32,
+) -> Result<()> {
+    let mut config = build_config(cache_dir, Some(bucket), prefix, endpoint, region, true);
+    config.prefetch_threads = threads;
+
+    let vfs_name = format!("turbolite-prefetch-{}", std::process::id());
+    let (shared, conn) = open_shared(&db, config, &vfs_name)?;
+
+    let manifest = shared.manifest();
+    let total_groups = manifest.page_group_keys.len();
+
+    // Connection open already fetches interior + index pages eagerly.
+    // Now scan every table to pull all data pages into the local cache.
+    let tables: Vec<String> = {
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .context("failed to list tables")?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .context("failed to query tables")?;
+        rows.filter_map(|r| r.ok()).collect()
+    };
+
+    for table in &tables {
+        // Full scan triggers prefetch of all data page groups for this table
+        let sql = format!("SELECT COUNT(*) FROM \"{}\"", table.replace('"', "\"\""));
+        let _: i64 = conn
+            .query_row(&sql, [], |row| row.get(0))
+            .unwrap_or(0);
+    }
+
+    let (fetches, bytes) = shared.s3_counters();
+    println!(
+        "prefetch: {} tables, {} groups, {} S3 GETs, {:.1} MB fetched",
+        tables.len(),
+        total_groups,
+        fetches,
+        bytes as f64 / (1024.0 * 1024.0),
+    );
+
+    Ok(())
+}
+
+fn cmd_export(
+    db: PathBuf,
+    output: PathBuf,
+    bucket: Option<String>,
+    prefix: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    cache_dir: PathBuf,
+) -> Result<()> {
+    let config = build_config(cache_dir, bucket, prefix, endpoint, region, true);
+    let vfs_name = format!("turbolite-export-{}", std::process::id());
+    let src_conn = open_connection(&db, config, &vfs_name)?;
+
+    // Open a plain SQLite destination (no VFS) and use the backup API
+    // to copy all pages. This produces a standard SQLite file.
+    let mut dst_conn = rusqlite::Connection::open(&output)
+        .context("failed to create output file")?;
+
+    let backup = rusqlite::backup::Backup::new(&src_conn, &mut dst_conn)
+        .context("failed to initialize backup")?;
+
+    backup
+        .run_to_completion(100, std::time::Duration::from_millis(0), None)
+        .context("backup failed")?;
+
+    drop(backup);
+
+    // Verify the output is a valid SQLite file
+    let integrity: String = dst_conn
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .context("integrity check failed")?;
+
+    if integrity != "ok" {
+        return Err(anyhow!(
+            "exported file failed integrity check: {}",
+            integrity
+        ));
+    }
+
+    let file_size = std::fs::metadata(&output)?.len();
+    println!(
+        "export: {} -> {} ({:.1} MB, integrity ok)",
+        db.display(),
+        output.display(),
+        file_size as f64 / (1024.0 * 1024.0),
+    );
+
+    Ok(())
+}
+
+#[cfg(feature = "cloud")]
+fn cmd_import(
+    input: PathBuf,
+    bucket: String,
+    prefix: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    pages_per_group: u32,
+    compression_level: i32,
+) -> Result<()> {
+    use turbolite::tiered::{StorageBackend, TurboliteConfig};
+
+    let prefix_str = prefix.unwrap_or_default();
+    let config = TurboliteConfig {
+        storage_backend: StorageBackend::S3 {
+            bucket: bucket.clone(),
+            prefix: prefix_str.clone(),
+            endpoint_url: endpoint.clone(),
+            region: region.clone(),
+        },
+        bucket: bucket.clone(),
+        prefix: prefix_str,
+        endpoint_url: endpoint,
+        region,
+        pages_per_group,
+        compression_level,
+        ..Default::default()
+    };
+
+    let manifest = turbolite::tiered::import_sqlite_file(&config, &input)
+        .map_err(|e| anyhow!("import failed: {}", e))?;
+
+    println!(
+        "import: {} -> s3://{}/{} ({} pages, {} groups, manifest v{})",
+        input.display(),
+        config.bucket,
+        config.prefix,
+        manifest.page_count,
+        manifest.page_group_keys.len(),
+        manifest.version,
+    );
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Version) => {
+        Commands::Version => {
             println!("turbolite {}", env!("CARGO_PKG_VERSION"));
         }
-        None => {
-            let mut command = Cli::command();
-            command.print_help().expect("failed to print help");
-            println!();
+        Commands::Info { db, bucket, prefix, endpoint, region, cache_dir } => {
+            cmd_info(db, bucket, prefix, endpoint, region, cache_dir)?;
+        }
+        Commands::Shell { db, bucket, prefix, endpoint, region, cache_dir, read_only } => {
+            cmd_shell(db, bucket, prefix, endpoint, region, cache_dir, read_only)?;
+        }
+        Commands::Gc { db, bucket, prefix, endpoint, region, cache_dir } => {
+            cmd_gc(db, bucket, prefix, endpoint, region, cache_dir)?;
+        }
+        Commands::Checkpoint { db, bucket, prefix, endpoint, region, cache_dir } => {
+            cmd_checkpoint(db, bucket, prefix, endpoint, region, cache_dir)?;
+        }
+        Commands::Prefetch { db, bucket, prefix, endpoint, region, cache_dir, threads } => {
+            cmd_prefetch(db, bucket, prefix, endpoint, region, cache_dir, threads)?;
+        }
+        Commands::Export { db, output, bucket, prefix, endpoint, region, cache_dir } => {
+            cmd_export(db, output, bucket, prefix, endpoint, region, cache_dir)?;
+        }
+        Commands::Import {
+            input, bucket, prefix, endpoint, region,
+            pages_per_group, compression_level,
+        } => {
+            #[cfg(feature = "cloud")]
+            cmd_import(input, bucket, prefix, endpoint, region, pages_per_group, compression_level)?;
+
+            #[cfg(not(feature = "cloud"))]
+            return Err(anyhow!("import requires the 'cloud' feature. Rebuild with: cargo build --features cloud,zstd"));
         }
     }
+
+    Ok(())
 }

--- a/tests/cli_s3_test.rs
+++ b/tests/cli_s3_test.rs
@@ -1,0 +1,347 @@
+//! CLI integration tests against Tigris (S3-compatible).
+//!
+//! Requires S3 credentials. Run with:
+//!
+//! ```bash
+//! soup run --project ladybug --env development -- \
+//!   TIERED_TEST_BUCKET=sqlces-test \
+//!   AWS_ACCESS_KEY_ID=$TIGRIS_STORAGE_ACCESS_KEY_ID \
+//!   AWS_SECRET_ACCESS_KEY=$TIGRIS_STORAGE_SECRET_ACCESS_KEY \
+//!   AWS_ENDPOINT_URL=$TIGRIS_STORAGE_ENDPOINT \
+//!   cargo test --test cli_s3_test --features cloud,zstd
+//! ```
+
+#![cfg(feature = "cloud")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn turbolite_bin() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("target");
+    path.push("debug");
+    path.push("turbolite");
+    path
+}
+
+fn build_bin() {
+    let status = Command::new("cargo")
+        .args(["build", "--bin", "turbolite", "--features", "cloud,zstd"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .status()
+        .expect("failed to build turbolite binary");
+    assert!(status.success(), "cargo build failed");
+}
+
+fn test_bucket() -> String {
+    std::env::var("TIERED_TEST_BUCKET")
+        .expect("TIERED_TEST_BUCKET env var required for S3 CLI tests")
+}
+
+fn endpoint_url() -> String {
+    std::env::var("AWS_ENDPOINT_URL")
+        .unwrap_or_else(|_| "https://t3.storage.dev".to_string())
+}
+
+fn unique_prefix() -> String {
+    format!(
+        "test/cli/{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time")
+            .as_nanos()
+    )
+}
+
+/// Create a plain SQLite database for import testing.
+fn create_plain_db(dir: &std::path::Path, name: &str) -> PathBuf {
+    let db_path = dir.join(name);
+    let conn = rusqlite::Connection::open(&db_path).expect("create plain db");
+    conn.execute_batch("PRAGMA page_size=65536; PRAGMA journal_mode=DELETE;")
+        .expect("set page size");
+    conn.execute_batch(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT);
+         INSERT INTO users VALUES (1, 'alice', 'alice@example.com');
+         INSERT INTO users VALUES (2, 'bob', 'bob@example.com');
+         INSERT INTO users VALUES (3, 'charlie', 'charlie@example.com');
+         CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER, title TEXT, body TEXT);
+         INSERT INTO posts VALUES (1, 1, 'Hello World', 'First post content');
+         INSERT INTO posts VALUES (2, 2, 'Testing', 'Test post body');
+         INSERT INTO posts VALUES (3, 1, 'Another', 'More content here');
+         CREATE INDEX idx_posts_user ON posts(user_id);",
+    )
+    .expect("populate plain db");
+    conn.close().expect("close plain db");
+    db_path
+}
+
+/// Run a CLI command with S3 env vars inherited from the test process.
+fn run_cli(args: &[&str]) -> std::process::Output {
+    Command::new(turbolite_bin())
+        .args(args)
+        .output()
+        .expect("failed to run turbolite CLI")
+}
+
+// ── import -> info -> export roundtrip ─────────────────────────────
+
+#[test]
+fn test_import_info_export_roundtrip() {
+    build_bin();
+
+    let tmpdir = tempfile::tempdir().expect("tmpdir");
+    let plain_db = create_plain_db(tmpdir.path(), "source.db");
+    let bucket = test_bucket();
+    let endpoint = endpoint_url();
+    let prefix = unique_prefix();
+
+    // 1. Import plain SQLite to Tigris
+    let output = run_cli(&[
+        "import",
+        "--input",
+        plain_db.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+    ]);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "import failed.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(stdout.contains("import:"), "should print import summary");
+    assert!(stdout.contains("pages"), "should mention page count");
+    assert!(stdout.contains("groups"), "should mention group count");
+
+    // 2. Info on the imported database
+    let cache_dir = tmpdir.path().join("info-cache");
+    let db_path = tmpdir.path().join("info.db");
+    let output = run_cli(&[
+        "info",
+        "--db",
+        db_path.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+        "--cache-dir",
+        cache_dir.to_str().expect("path"),
+    ]);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "info failed.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(stdout.contains("S3"), "should show S3 storage");
+    assert!(stdout.contains("pages:"), "should show page count");
+    assert!(stdout.contains("page groups:"), "should show group count");
+
+    // 3. Export back to plain SQLite
+    let export_dir = tempfile::tempdir().expect("export tmpdir");
+    let exported_db = export_dir.path().join("exported.db");
+    let export_cache = tmpdir.path().join("export-cache");
+    let export_db_path = tmpdir.path().join("export.db");
+
+    let output = run_cli(&[
+        "export",
+        "--db",
+        export_db_path.to_str().expect("path"),
+        "--output",
+        exported_db.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+        "--cache-dir",
+        export_cache.to_str().expect("path"),
+    ]);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "export failed.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(stdout.contains("integrity ok"), "should pass integrity check");
+
+    // 4. Verify exported data matches original
+    let conn = rusqlite::Connection::open(&exported_db).expect("open exported db");
+
+    let user_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM users", [], |row| row.get(0))
+        .expect("count users");
+    assert_eq!(user_count, 3, "should have 3 users");
+
+    let post_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM posts", [], |row| row.get(0))
+        .expect("count posts");
+    assert_eq!(post_count, 3, "should have 3 posts");
+
+    let alice_email: String = conn
+        .query_row(
+            "SELECT email FROM users WHERE name = 'alice'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("query alice");
+    assert_eq!(alice_email, "alice@example.com");
+
+    // Verify index survived roundtrip
+    let has_index: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='index' AND name='idx_posts_user'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("check index");
+    assert!(has_index, "index should survive import/export roundtrip");
+}
+
+// ── gc on clean prefix ─────────────────────────────────────────────
+
+#[test]
+fn test_gc_clean_prefix() {
+    build_bin();
+
+    let tmpdir = tempfile::tempdir().expect("tmpdir");
+    let plain_db = create_plain_db(tmpdir.path(), "gc-source.db");
+    let bucket = test_bucket();
+    let endpoint = endpoint_url();
+    let prefix = unique_prefix();
+
+    // Import first to create S3 data
+    let output = run_cli(&[
+        "import",
+        "--input",
+        plain_db.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+    ]);
+    assert!(output.status.success(), "import failed for gc test");
+
+    // Run GC on clean prefix (no orphans expected)
+    let cache_dir = tmpdir.path().join("gc-cache");
+    let db_path = tmpdir.path().join("gc.db");
+    let output = run_cli(&[
+        "gc",
+        "--db",
+        db_path.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+        "--cache-dir",
+        cache_dir.to_str().expect("path"),
+    ]);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "gc failed.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("no orphaned objects") || stdout.contains("deleted"),
+        "should report gc result: {}",
+        stdout
+    );
+}
+
+// ── shell against S3 database ──────────────────────────────────────
+
+#[test]
+fn test_shell_s3_query() {
+    build_bin();
+
+    let tmpdir = tempfile::tempdir().expect("tmpdir");
+    let plain_db = create_plain_db(tmpdir.path(), "shell-source.db");
+    let bucket = test_bucket();
+    let endpoint = endpoint_url();
+    let prefix = unique_prefix();
+
+    // Import first
+    let output = run_cli(&[
+        "import",
+        "--input",
+        plain_db.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+    ]);
+    assert!(output.status.success(), "import failed for shell test");
+
+    // Query via shell
+    let cache_dir = tmpdir.path().join("shell-cache");
+    let db_path = tmpdir.path().join("shell.db");
+
+    let output = Command::new(turbolite_bin())
+        .args([
+            "shell",
+            "--db",
+            db_path.to_str().expect("path"),
+            "--bucket",
+            &bucket,
+            "--prefix",
+            &prefix,
+            "--endpoint",
+            &endpoint,
+            "--cache-dir",
+            cache_dir.to_str().expect("path"),
+            "--read-only",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(
+                    b"SELECT name FROM users ORDER BY id;\nSELECT COUNT(*) FROM posts;\n.quit\n",
+                )?;
+            }
+            child.wait_with_output()
+        })
+        .expect("failed to run shell");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "shell failed.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(stdout.contains("alice"), "should contain alice");
+    assert!(stdout.contains("bob"), "should contain bob");
+    assert!(stdout.contains("charlie"), "should contain charlie");
+    assert!(stdout.contains("3"), "should show post count of 3");
+}

--- a/tests/cli_s3_test.rs
+++ b/tests/cli_s3_test.rs
@@ -214,64 +214,6 @@ fn test_import_info_export_roundtrip() {
     assert!(has_index, "index should survive import/export roundtrip");
 }
 
-// ── gc on clean prefix ─────────────────────────────────────────────
-
-#[test]
-fn test_gc_clean_prefix() {
-    build_bin();
-
-    let tmpdir = tempfile::tempdir().expect("tmpdir");
-    let plain_db = create_plain_db(tmpdir.path(), "gc-source.db");
-    let bucket = test_bucket();
-    let endpoint = endpoint_url();
-    let prefix = unique_prefix();
-
-    // Import first to create S3 data
-    let output = run_cli(&[
-        "import",
-        "--input",
-        plain_db.to_str().expect("path"),
-        "--bucket",
-        &bucket,
-        "--prefix",
-        &prefix,
-        "--endpoint",
-        &endpoint,
-    ]);
-    assert!(output.status.success(), "import failed for gc test");
-
-    // Run GC on clean prefix (no orphans expected)
-    let cache_dir = tmpdir.path().join("gc-cache");
-    let db_path = tmpdir.path().join("gc.db");
-    let output = run_cli(&[
-        "gc",
-        "--db",
-        db_path.to_str().expect("path"),
-        "--bucket",
-        &bucket,
-        "--prefix",
-        &prefix,
-        "--endpoint",
-        &endpoint,
-        "--cache-dir",
-        cache_dir.to_str().expect("path"),
-    ]);
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "gc failed.\nstdout: {}\nstderr: {}",
-        stdout,
-        stderr
-    );
-    assert!(
-        stdout.contains("no orphaned objects") || stdout.contains("deleted"),
-        "should report gc result: {}",
-        stdout
-    );
-}
-
 // ── shell against S3 database ──────────────────────────────────────
 
 #[test]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,0 +1,443 @@
+//! Integration tests for the turbolite CLI binary.
+//!
+//! These tests invoke the compiled binary and check output/exit codes.
+//! They test local-mode commands (no S3 required).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn turbolite_bin() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("target");
+    path.push("debug");
+    path.push("turbolite");
+    path
+}
+
+fn build_bin() {
+    let status = Command::new("cargo")
+        .args(["build", "--bin", "turbolite", "--features", "cloud,zstd"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .status()
+        .expect("failed to build turbolite binary");
+    assert!(status.success(), "cargo build failed");
+}
+
+/// Create a turbolite database by piping SQL through the shell command.
+/// Returns the db path.
+fn create_turbolite_db(dir: &std::path::Path, name: &str) -> PathBuf {
+    let db_path = dir.join(name);
+    let cache_dir = dir.join(format!("{}-cache", name));
+
+    let output = Command::new(turbolite_bin())
+        .args([
+            "shell",
+            "--db",
+            db_path.to_str().expect("path"),
+            "--cache-dir",
+            cache_dir.to_str().expect("cache path"),
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(
+                    b"CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT);\n\
+                      INSERT INTO users VALUES (1, 'alice', 'alice@example.com');\n\
+                      INSERT INTO users VALUES (2, 'bob', 'bob@example.com');\n\
+                      INSERT INTO users VALUES (3, 'charlie', 'charlie@example.com');\n\
+                      CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER, title TEXT);\n\
+                      INSERT INTO posts VALUES (1, 1, 'Hello World');\n\
+                      INSERT INTO posts VALUES (2, 2, 'Testing');\n\
+                      .quit\n",
+                )?;
+            }
+            child.wait_with_output()
+        })
+        .expect("failed to create test db via shell");
+
+    assert!(
+        output.status.success(),
+        "failed to create test db. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    db_path
+}
+
+// ── version ────────────────────────────────────────────────────────
+
+#[test]
+fn test_version_subcommand() {
+    build_bin();
+    let output = Command::new(turbolite_bin())
+        .arg("version")
+        .output()
+        .expect("failed to run turbolite version");
+
+    assert!(output.status.success(), "exit code was not 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("turbolite"),
+        "expected 'turbolite' in output, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains('.'),
+        "expected version number with '.', got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_version_flag() {
+    build_bin();
+    let output = Command::new(turbolite_bin())
+        .arg("--version")
+        .output()
+        .expect("failed to run turbolite --version");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("turbolite"));
+}
+
+// ── help ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_help_flag() {
+    build_bin();
+    let output = Command::new(turbolite_bin())
+        .arg("--help")
+        .output()
+        .expect("failed to run turbolite --help");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("info"), "help should mention info command");
+    assert!(stdout.contains("shell"), "help should mention shell command");
+    assert!(stdout.contains("gc"), "help should mention gc command");
+    assert!(stdout.contains("export"), "help should mention export command");
+    assert!(stdout.contains("import"), "help should mention import command");
+    assert!(
+        stdout.contains("checkpoint"),
+        "help should mention checkpoint command"
+    );
+    assert!(
+        stdout.contains("prefetch"),
+        "help should mention prefetch command"
+    );
+}
+
+// ── info (local mode) ──────────────────────────────────────────────
+
+#[test]
+fn test_info_local() {
+    build_bin();
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let db_path = create_turbolite_db(tmpdir.path(), "info.db");
+    let cache_dir = tmpdir.path().join("info.db-cache");
+
+    let output = Command::new(turbolite_bin())
+        .args([
+            "info",
+            "--db",
+            db_path.to_str().expect("path"),
+            "--cache-dir",
+            cache_dir.to_str().expect("path"),
+        ])
+        .output()
+        .expect("failed to run turbolite info");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "info failed. stdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(stdout.contains("pages:"), "should show page count");
+    assert!(stdout.contains("page size:"), "should show page size");
+    assert!(stdout.contains("local"), "should show storage type as local");
+    assert!(
+        stdout.contains("manifest version:"),
+        "should show manifest version"
+    );
+}
+
+// ── export ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_export_local() {
+    build_bin();
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let db_path = create_turbolite_db(tmpdir.path(), "export-src.db");
+    let cache_dir = tmpdir.path().join("export-src.db-cache");
+    let export_dir = tempfile::tempdir().expect("export tmpdir");
+    let output_path = export_dir.path().join("exported.db");
+
+    let output = Command::new(turbolite_bin())
+        .args([
+            "export",
+            "--db",
+            db_path.to_str().expect("path"),
+            "--output",
+            output_path.to_str().expect("path"),
+            "--cache-dir",
+            cache_dir.to_str().expect("path"),
+        ])
+        .output()
+        .expect("failed to run turbolite export");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "export failed. stdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(stdout.contains("integrity ok"), "should pass integrity check");
+
+    // Verify the exported file has correct data (plain SQLite, no VFS needed)
+    let conn =
+        rusqlite::Connection::open(&output_path).expect("open exported db");
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM users", [], |row| row.get(0))
+        .expect("query exported db");
+    assert_eq!(count, 3, "exported db should have 3 users");
+
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM posts", [], |row| row.get(0))
+        .expect("query exported db");
+    assert_eq!(count, 2, "exported db should have 2 posts");
+}
+
+// ── shell (non-interactive, piped input) ───────────────────────────
+
+#[test]
+fn test_shell_piped_query() {
+    build_bin();
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let db_path = create_turbolite_db(tmpdir.path(), "shell-query.db");
+    let cache_dir = tmpdir.path().join("shell-query.db-cache");
+
+    let output = Command::new(turbolite_bin())
+        .args([
+            "shell",
+            "--db",
+            db_path.to_str().expect("path"),
+            "--cache-dir",
+            cache_dir.to_str().expect("path"),
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(b"SELECT name FROM users ORDER BY id;\n.quit\n")?;
+            }
+            child.wait_with_output()
+        })
+        .expect("failed to run turbolite shell");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "shell failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("alice"), "should contain alice");
+    assert!(stdout.contains("bob"), "should contain bob");
+    assert!(stdout.contains("charlie"), "should contain charlie");
+}
+
+#[test]
+fn test_shell_dot_tables() {
+    build_bin();
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let db_path = create_turbolite_db(tmpdir.path(), "tables.db");
+    let cache_dir = tmpdir.path().join("tables.db-cache");
+
+    let output = Command::new(turbolite_bin())
+        .args([
+            "shell",
+            "--db",
+            db_path.to_str().expect("path"),
+            "--cache-dir",
+            cache_dir.to_str().expect("path"),
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(b".tables\n.quit\n")?;
+            }
+            child.wait_with_output()
+        })
+        .expect("failed to run turbolite shell");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(stdout.contains("users"), "should list users table");
+    assert!(stdout.contains("posts"), "should list posts table");
+}
+
+#[test]
+fn test_shell_dot_schema() {
+    build_bin();
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let db_path = create_turbolite_db(tmpdir.path(), "schema.db");
+    let cache_dir = tmpdir.path().join("schema.db-cache");
+
+    let output = Command::new(turbolite_bin())
+        .args([
+            "shell",
+            "--db",
+            db_path.to_str().expect("path"),
+            "--cache-dir",
+            cache_dir.to_str().expect("path"),
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(b".schema\n.quit\n")?;
+            }
+            child.wait_with_output()
+        })
+        .expect("failed to run turbolite shell");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(
+        stdout.contains("CREATE TABLE"),
+        "should show CREATE TABLE statements"
+    );
+}
+
+#[test]
+fn test_shell_write_and_read() {
+    build_bin();
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let db_path = create_turbolite_db(tmpdir.path(), "write.db");
+    let cache_dir = tmpdir.path().join("write.db-cache");
+
+    let output = Command::new(turbolite_bin())
+        .args([
+            "shell",
+            "--db",
+            db_path.to_str().expect("path"),
+            "--cache-dir",
+            cache_dir.to_str().expect("path"),
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(
+                    b"INSERT INTO users VALUES (4, 'dave', 'dave@example.com');\nSELECT COUNT(*) FROM users;\n.quit\n",
+                )?;
+            }
+            child.wait_with_output()
+        })
+        .expect("failed to run turbolite shell");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    // After inserting dave, count should be 4
+    assert!(stdout.contains("4"), "should show count of 4 after insert");
+}
+
+// ── missing args ───────────────────────────────────────────────────
+
+#[test]
+fn test_info_missing_db_arg() {
+    build_bin();
+    let output = Command::new(turbolite_bin())
+        .arg("info")
+        .output()
+        .expect("failed to run turbolite info");
+
+    assert!(!output.status.success(), "should fail without --db");
+}
+
+#[test]
+fn test_gc_missing_bucket() {
+    build_bin();
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let db_path = tmpdir.path().join("gc.db");
+
+    // gc requires --bucket, should fail without it
+    let output = Command::new(turbolite_bin())
+        .args(["gc", "--db", db_path.to_str().expect("path")])
+        .output()
+        .expect("failed to run turbolite gc");
+
+    assert!(!output.status.success(), "gc should fail without --bucket");
+}
+
+// ── no subcommand shows error ──────────────────────────────────────
+
+#[test]
+fn test_no_subcommand_shows_error() {
+    build_bin();
+    let output = Command::new(turbolite_bin())
+        .output()
+        .expect("failed to run turbolite");
+
+    assert!(!output.status.success(), "should fail with no subcommand");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage") || stderr.contains("turbolite"),
+        "should show usage info"
+    );
+}
+
+// ── export nonexistent db ──────────────────────────────────────────
+
+#[test]
+fn test_export_nonexistent_db() {
+    build_bin();
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let output_path = tmpdir.path().join("exported.db");
+    let cache_dir = tmpdir.path().join("cache");
+
+    let output = Command::new(turbolite_bin())
+        .args([
+            "export",
+            "--db",
+            "/nonexistent/path/db.sqlite",
+            "--output",
+            output_path.to_str().expect("path"),
+            "--cache-dir",
+            cache_dir.to_str().expect("path"),
+        ])
+        .output()
+        .expect("failed to run turbolite export");
+
+    // Should fail (the VFS will create a new empty db, then VACUUM INTO will produce
+    // a valid but empty file, or it may fail depending on the path). Either way,
+    // verify the binary doesn't crash.
+    // The actual behavior depends on whether the path is writable.
+    // For a truly nonexistent parent dir, it should fail.
+    assert!(
+        !output.status.success(),
+        "should fail for nonexistent db path"
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -71,28 +71,6 @@ fn create_turbolite_db(dir: &std::path::Path, name: &str) -> PathBuf {
 // ── version ────────────────────────────────────────────────────────
 
 #[test]
-fn test_version_subcommand() {
-    build_bin();
-    let output = Command::new(turbolite_bin())
-        .arg("version")
-        .output()
-        .expect("failed to run turbolite version");
-
-    assert!(output.status.success(), "exit code was not 0");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("turbolite"),
-        "expected 'turbolite' in output, got: {}",
-        stdout
-    );
-    assert!(
-        stdout.contains('.'),
-        "expected version number with '.', got: {}",
-        stdout
-    );
-}
-
-#[test]
 fn test_version_flag() {
     build_bin();
     let output = Command::new(turbolite_bin())
@@ -119,13 +97,8 @@ fn test_help_flag() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("info"), "help should mention info command");
     assert!(stdout.contains("shell"), "help should mention shell command");
-    assert!(stdout.contains("gc"), "help should mention gc command");
     assert!(stdout.contains("export"), "help should mention export command");
     assert!(stdout.contains("import"), "help should mention import command");
-    assert!(
-        stdout.contains("checkpoint"),
-        "help should mention checkpoint command"
-    );
     assert!(
         stdout.contains("download"),
         "help should mention download command"
@@ -375,21 +348,6 @@ fn test_info_missing_db_arg() {
         .expect("failed to run turbolite info");
 
     assert!(!output.status.success(), "should fail without --db");
-}
-
-#[test]
-fn test_gc_missing_bucket() {
-    build_bin();
-    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
-    let db_path = tmpdir.path().join("gc.db");
-
-    // gc requires --bucket, should fail without it
-    let output = Command::new(turbolite_bin())
-        .args(["gc", "--db", db_path.to_str().expect("path")])
-        .output()
-        .expect("failed to run turbolite gc");
-
-    assert!(!output.status.success(), "gc should fail without --bucket");
 }
 
 // ── no subcommand shows error ──────────────────────────────────────

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -127,8 +127,8 @@ fn test_help_flag() {
         "help should mention checkpoint command"
     );
     assert!(
-        stdout.contains("prefetch"),
-        "help should mention prefetch command"
+        stdout.contains("download"),
+        "help should mention download command"
     );
 }
 


### PR DESCRIPTION
## Summary
- Replace placeholder CLI binary with 5 commands: `info`, `shell`, `import`, `export`, `download`
- `info`: manifest summary (pages, groups, B-trees, storage type, seekable frames)
- `shell`: interactive SQLite REPL through turbolite VFS with `.tables`, `.schema`, `.quit`
- `import`: bulk import plain SQLite to turbolite S3 format (B-tree-aware grouping, seekable zstd)
- `export`: backup to plain SQLite via SQLite backup API
- `download`: pull entire database from S3 into local cache
- All S3 commands accept `--bucket`, `--prefix`, `--endpoint`, `--region` flags or env vars (`TURBOLITE_BUCKET`, `TURBOLITE_PREFIX`, `AWS_ENDPOINT_URL`, `AWS_REGION`)
- Add `backup` feature to rusqlite dependency for export
- Phase Mercury added to CHANGELOG, CLI section added to README

## Test plan
- [x] 11 local integration tests (invoke compiled binary, check output/exit codes)
  - --version flag
  - --help lists all commands
  - info on local turbolite database shows pages, page size, storage type
  - shell: piped SQL query returns correct data
  - shell: .tables lists tables, .schema shows CREATE statements
  - shell: write + read roundtrip
  - export produces valid plain SQLite with correct data (3 users, 2 posts)
  - missing required args fail with appropriate errors
  - no subcommand shows usage
- [x] 2 Tigris S3 integration tests (real Tigris, not mocked)
  - import -> info -> export full roundtrip: plain SQLite to Tigris, verify manifest, export back, verify 3 users + 3 posts + index survives
  - shell queries S3-backed database, returns correct rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)