### PR TITLE
fix: gate migrate function behind bundled-sqlite feature

### DIFF
--- a/src/tiered/mod.rs
+++ b/src/tiered/mod.rs
@@ -352,6 +352,7 @@ pub fn register_shared(name: &str, vfs: SharedTurboliteVfs) -> Result<(), io::Er
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))
 }
 
+#[cfg(feature = "bundled-sqlite")]
 /// Migrate a database to S3Primary mode (journal_mode=OFF).
 ///
 /// This function handles the full migration regardless of the current journal mode:


### PR DESCRIPTION
## Summary
- Gate `turbolite_migrate_to_s3_primary` behind `#[cfg(feature = "bundled-sqlite")]`
- The function uses `rusqlite::Connection` which is only available with bundled-sqlite
- Fixes the loadable extension CI build (`--no-default-features --features loadable-extension,zstd`) which has been failing on main

## Test plan
- [x] `cargo build --release --lib --no-default-features --features loadable-extension,zstd` compiles clean locally
- [x] CI should pass (build-ext job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)