### PR TITLE
fix: resolve all 53 compiler warnings

### DIFF
--- a/benchmark/turbolite-bench.rs
+++ b/benchmark/turbolite-bench.rs
@@ -440,7 +440,7 @@ fn bench_with_corpus(
     cache_percent: f64,
     mmap_percent: f64,
     wal_autocheckpoint: i64,
-    encryption_key: &str,
+    _encryption_key: &str,
     fresh: bool,
     vfs_counter: &std::sync::atomic::AtomicU32,
 ) -> Result<BenchmarkResult, Box<dyn std::error::Error>> {
@@ -675,7 +675,7 @@ fn bench_existing_db(
     cache_percent: f64,
     mmap_percent: f64,
     wal_autocheckpoint: i64,
-    encryption_key: Option<&str>,
+    _encryption_key: Option<&str>,
 ) -> Result<BenchmarkResult, Box<dyn std::error::Error>> {
     let start_total = Instant::now();
 

--- a/src/tiered/cache_tracking.rs
+++ b/src/tiered/cache_tracking.rs
@@ -62,6 +62,7 @@ impl PageBitmap {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn clear_range(&self, start: u64, count: u64) {
         for p in start..start + count {
             self.clear(p);
@@ -198,6 +199,7 @@ impl SubChunkTracker {
 
     /// Compute which sub-chunk a page belongs to (LEGACY: positional mapping).
     /// Only valid for positional groups. For B-tree-aware groups, use sub_chunk_id_for().
+    #[allow(dead_code)]
     pub(crate) fn sub_chunk_for_page(&self, page_num: u64) -> SubChunkId {
         let ppg = self.pages_per_group;
         let spf = self.sub_pages_per_frame;
@@ -219,6 +221,7 @@ impl SubChunkTracker {
     }
 
     /// Check if the sub-chunk containing this page is cached.
+    #[allow(dead_code)]
     pub(crate) fn is_present(&self, page_num: u64) -> bool {
         let id = self.sub_chunk_for_page(page_num);
         self.present.contains(&id)
@@ -293,6 +296,7 @@ impl SubChunkTracker {
     }
 
     /// Touch the sub-chunk containing a page.
+    #[allow(dead_code)]
     pub(crate) fn touch_page(&mut self, page_num: u64) {
         let id = self.sub_chunk_for_page(page_num);
         self.touch(id);
@@ -301,6 +305,7 @@ impl SubChunkTracker {
     /// Evict one sub-chunk: pick the lowest-priority (highest tier number),
     /// least-recently-used sub-chunk. Returns the evicted sub-chunk or None if empty.
     /// Never evicts Pinned (tier 0) sub-chunks.
+    #[allow(dead_code)]
     pub(crate) fn evict_one(&mut self) -> Option<SubChunkId> {
         self.evict_one_skipping(&HashSet::new())
     }
@@ -317,6 +322,7 @@ impl SubChunkTracker {
     /// Data scores range [0.0, 2.0]. Index scores range [10.0, 12.0].
     /// Tier always dominates: the hottest Data (2.0) is evicted before the coldest Index (10.0).
     /// Within a tier, frequency + recency break ties.
+    #[allow(dead_code)]
     pub(crate) fn evict_one_skipping(&mut self, skip_groups: &HashSet<u64>) -> Option<SubChunkId> {
         let now = Instant::now();
         let max_age = Duration::from_secs(RECENCY_WINDOW_SECS);
@@ -402,6 +408,7 @@ impl SubChunkTracker {
     }
 
     /// Evict all sub-chunks in a specific tier that are older than `ttl`.
+    #[allow(dead_code)]
     pub(crate) fn evict_expired_in_tier(&mut self, tier: SubChunkTier, ttl: Duration) -> Vec<SubChunkId> {
         let now = Instant::now();
         let expired: Vec<SubChunkId> = self.present.iter()
@@ -441,6 +448,7 @@ impl SubChunkTracker {
     }
 
     /// Clear all non-pinned sub-chunks (for cold benchmarks).
+    #[allow(dead_code)]
     pub(crate) fn clear_data(&mut self) {
         let to_remove: Vec<SubChunkId> = self.present.iter()
             .filter(|id| {
@@ -492,6 +500,7 @@ impl SubChunkTracker {
     }
 
     /// Number of tracked sub-chunks.
+    #[allow(dead_code)]
     pub(crate) fn len(&self) -> usize {
         self.present.len()
     }

--- a/src/tiered/compact.rs
+++ b/src/tiered/compact.rs
@@ -12,6 +12,7 @@ use super::*;
 
 /// Per-B-tree dead space analysis.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct BTreeDeadSpace {
     pub name: String,
     pub root_page: u64,
@@ -29,6 +30,7 @@ pub struct DeadSpaceReport {
     pub btrees: Vec<BTreeDeadSpace>,
     pub total_live: usize,
     pub total_dead: usize,
+    #[allow(dead_code)]
     pub total_in_groups: usize,
     /// B-trees exceeding the compaction threshold.
     pub candidates: Vec<String>,
@@ -183,6 +185,7 @@ pub fn compact_btree(
 pub struct CompactResult {
     pub btree_name: String,
     pub old_group_ids: Vec<u64>,
+    #[allow(dead_code)]
     pub old_keys: Vec<String>,
     /// New dense-packed page lists (one per new group).
     pub new_groups: Vec<Vec<u64>>,

--- a/src/tiered/disk_cache.rs
+++ b/src/tiered/disk_cache.rs
@@ -173,6 +173,7 @@ pub(crate) struct DiskCache {
     pub(crate) sub_pages_per_frame: u32,
     pub(crate) page_size: std::sync::atomic::AtomicU32,
     /// Encryption key for cache-at-rest. Uses CTR mode (no size overhead).
+    #[allow(dead_code)]
     pub(crate) encryption_key: Option<[u8; 32]>,
     /// B-tree-aware page-to-group mapping: group_pages[gid] = list of page numbers.
     /// Used by evict_group and clear_cache to clear the correct bitmap bits.
@@ -211,6 +212,7 @@ pub(crate) struct DiskCache {
 /// Counter for lazy eviction (every 64 group fetches).
 pub(crate) static EVICTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+#[allow(dead_code)]
 impl DiskCache {
     pub(crate) fn new(cache_dir: &Path, ttl_secs: u64, pages_per_group: u32, sub_pages_per_frame: u32, page_size: u32, page_count: u64, encryption_key: Option<[u8; 32]>, group_pages: Vec<Vec<u64>>) -> io::Result<Self> {
         Self::new_with_compression(
@@ -591,7 +593,7 @@ impl DiskCache {
         let offset = page_num * self.page_size.load(Ordering::Acquire) as u64;
 
         // CTR encryption: same size, no overhead
-        let write_data: Vec<u8>;
+        let _write_data: Vec<u8>;
         #[cfg(feature = "encryption")]
         let data = if let Some(ref key) = self.encryption_key {
             write_data = compress::encrypt_ctr(data, page_num, key)?;
@@ -627,7 +629,7 @@ impl DiskCache {
         // Compress (with dictionary if available)
         #[cfg(feature = "zstd")]
         let ed = self.encoder_dict();
-        let mut blob = compress::compress(
+        let blob = compress::compress(
             data, self.cache_compression_level,
             #[cfg(feature = "zstd")]
             ed.as_ref(),
@@ -741,7 +743,7 @@ impl DiskCache {
             let end = (start + page_sz).min(data.len());
             let page_data = &data[start..end];
 
-            let mut compressed = compress::compress(
+            let compressed = compress::compress(
                 page_data, self.cache_compression_level,
                 #[cfg(feature = "zstd")]
                 ed.as_ref(),
@@ -898,7 +900,7 @@ impl DiskCache {
             let src_start = i * page_sz;
             let page_data = &data[src_start..src_start + page_sz];
 
-            let mut compressed = compress::compress(
+            let compressed = compress::compress(
                 page_data, self.cache_compression_level,
                 #[cfg(feature = "zstd")]
                 ed.as_ref(),
@@ -1298,7 +1300,7 @@ impl DiskCache {
     pub(crate) fn evict_to_budget(&self, budget_bytes: u64, skip_groups: &HashSet<u64>) -> u32 {
         // Collect and sort victims in one tracker lock
         let victims: Vec<SubChunkId> = {
-            let mut tracker = self.tracker.lock();
+            let tracker = self.tracker.lock();
             if tracker.current_cache_bytes <= budget_bytes {
                 return 0;
             }

--- a/src/tiered/encoding.rs
+++ b/src/tiered/encoding.rs
@@ -28,7 +28,7 @@ pub(crate) fn encode_page_group(
     page_size: u32,
     compression_level: i32,
     #[cfg(feature = "zstd")] encoder_dict: Option<&zstd::dict::EncoderDictionary<'static>>,
-    encryption_key: Option<&[u8; 32]>,
+    _encryption_key: Option<&[u8; 32]>,
 ) -> io::Result<Vec<u8>> {
     // Find last non-empty page to avoid trailing zeros
     let page_count = pages
@@ -87,7 +87,7 @@ pub(crate) fn encode_page_group_seekable(
     sub_ppg: u32,
     compression_level: i32,
     #[cfg(feature = "zstd")] encoder_dict: Option<&zstd::dict::EncoderDictionary<'static>>,
-    encryption_key: Option<&[u8; 32]>,
+    _encryption_key: Option<&[u8; 32]>,
 ) -> io::Result<(Vec<u8>, Vec<FrameEntry>)> {
     // Find last non-empty page to avoid trailing zeros
     let page_count = pages
@@ -122,7 +122,7 @@ pub(crate) fn encode_page_group_seekable(
         }
 
         let offset = blob.len() as u64;
-        let mut frame_data = compress::compress(
+        let frame_data = compress::compress(
             &raw,
             compression_level,
             #[cfg(feature = "zstd")]
@@ -319,7 +319,7 @@ pub(crate) fn encode_interior_bundle(
     page_size: u32,
     compression_level: i32,
     #[cfg(feature = "zstd")] encoder_dict: Option<&zstd::dict::EncoderDictionary<'static>>,
-    encryption_key: Option<&[u8; 32]>,
+    _encryption_key: Option<&[u8; 32]>,
 ) -> io::Result<Vec<u8>> {
     let page_count = pages.len() as u32;
     let header_len = 8 + pages.len() * 8; // 2×u32 + page_count×u64
@@ -427,7 +427,7 @@ pub(crate) fn encode_override_frame(
             raw.resize(raw.len() + page_size as usize - data.len(), 0);
         }
     }
-    let mut frame_data = compress::compress(
+    let frame_data = compress::compress(
         &raw, compression_level,
         #[cfg(feature = "zstd")] encoder_dict,
         #[cfg(not(feature = "zstd"))] None,

--- a/src/tiered/handle.rs
+++ b/src/tiered/handle.rs
@@ -486,10 +486,12 @@ impl TurboliteHandle {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn s3(&self) -> &S3Client {
         self.s3.as_ref().expect("s3 client required for tiered mode")
     }
 
+    #[allow(dead_code)]
     pub(crate) fn disk_cache(&self) -> &DiskCache {
         self.cache
             .as_ref()
@@ -497,6 +499,7 @@ impl TurboliteHandle {
     }
 
     /// Copy raw page data into the output buffer, handling sub-page offsets.
+    #[allow(dead_code)]
     pub(crate) fn copy_raw_into_buf(
         raw: &[u8],
         buf: &mut [u8],

--- a/src/tiered/http_client.rs
+++ b/src/tiered/http_client.rs
@@ -99,6 +99,7 @@ impl HttpClient {
         }
     }
 
+    #[allow(dead_code)]
     async fn range_get_async(&self, key: &str, start: u64, len: u32) -> io::Result<Option<Vec<u8>>> {
         let range = format!("bytes={}-{}", start, start + len as u64 - 1);
         let mut retries = 0u32;
@@ -211,6 +212,7 @@ impl HttpClient {
 
     // ── Parallel batch operations ──
 
+    #[allow(dead_code)]
     async fn get_page_groups_by_key_async(&self, keys: &[String]) -> io::Result<HashMap<String, Vec<u8>>> {
         let mut handles = Vec::with_capacity(keys.len());
         for key in keys {
@@ -324,6 +326,7 @@ impl HttpClient {
         Self::block_on(&self.runtime, self.get_object_async(key))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn get_page_groups_by_key(&self, keys: &[String]) -> io::Result<HashMap<String, Vec<u8>>> {
         Self::block_on(&self.runtime, self.get_page_groups_by_key_async(keys))
     }
@@ -336,6 +339,7 @@ impl HttpClient {
         Self::block_on(&self.runtime, self.delete_objects_async(keys))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn range_get(&self, key: &str, start: u64, len: u32) -> io::Result<Option<Vec<u8>>> {
         Self::block_on(&self.runtime, self.range_get_async(key, start, len))
     }

--- a/src/tiered/interior_map.rs
+++ b/src/tiered/interior_map.rs
@@ -186,6 +186,7 @@ impl InteriorMap {
 
     /// Find ALL leaf groups under a given interior page (recursive).
     /// Useful for SCAN: prefetch every leaf group in this subtree.
+    #[allow(dead_code)]
     pub fn subtree_groups(&self, interior_page: u64) -> Vec<u64> {
         let mut groups = Vec::new();
         let mut seen = std::collections::HashSet::new();
@@ -193,6 +194,7 @@ impl InteriorMap {
         groups
     }
 
+    #[allow(dead_code)]
     fn collect_subtree_groups(
         &self,
         page: u64,

--- a/src/tiered/mod.rs
+++ b/src/tiered/mod.rs
@@ -128,7 +128,6 @@ pub(crate) use cache_tracking::*;
 pub(crate) use disk_cache::*;
 pub(crate) use encoding::*;
 pub(crate) use prefetch::*;
-pub(crate) use query_plan::*;
 pub(crate) use s3_client::*;
 pub(crate) use storage_client::*;
 

--- a/src/tiered/overflow.rs
+++ b/src/tiered/overflow.rs
@@ -119,6 +119,7 @@ pub(crate) fn detect_overflow_pages(
 ///
 /// Each overflow page's first 4 bytes contain the next page number (1-based, 0 = end).
 /// The rest is overflow payload data.
+#[allow(dead_code)]
 pub(crate) fn follow_overflow_chain(
     first_page: u64,
     cache: &DiskCache,

--- a/src/tiered/prediction.rs
+++ b/src/tiered/prediction.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! Phase Verdun: Predictive cross-tree prefetch + access history.
 //!
 //! Learns which B-trees appear together in lock sessions (transactions/queries)

--- a/src/tiered/rotation.rs
+++ b/src/tiered/rotation.rs
@@ -1,9 +1,6 @@
 //! Encryption key rotation: re-encrypt all S3 data with a new key.
 
-use std::io;
 
-use super::*;
-use crate::compress;
 
 /// Re-encrypt, encrypt, or decrypt all S3 data.
 ///

--- a/src/tiered/s3_client.rs
+++ b/src/tiered/s3_client.rs
@@ -589,6 +589,7 @@ impl S3Client {
     }
 
     /// List all S3 keys under an arbitrary prefix (not limited to self.prefix).
+    #[allow(dead_code)]
     pub(crate) async fn list_all_keys_with_prefix(&self, prefix: &str) -> io::Result<Vec<String>> {
         let mut all_keys = Vec::new();
         let mut continuation_token: Option<String> = None;

--- a/src/tiered/staging.rs
+++ b/src/tiered/staging.rs
@@ -93,10 +93,12 @@ impl StagingWriter {
         Ok((self.path, self.pages_written))
     }
 
+    #[allow(dead_code)]
     pub fn path(&self) -> &Path {
         &self.path
     }
 
+    #[allow(dead_code)]
     pub fn pages_written(&self) -> u64 {
         self.pages_written
     }
@@ -110,7 +112,7 @@ pub(crate) fn read_staging_log(
 ) -> io::Result<HashMap<u64, Vec<u8>>> {
     let file = File::open(path)?;
     let file_len = file.metadata()?.len();
-    let record_size = 8 + page_size as u64;
+    let _record_size = 8 + page_size as u64;
 
     if file_len == 0 {
         return Ok(HashMap::new());

--- a/src/tiered/storage_client.rs
+++ b/src/tiered/storage_client.rs
@@ -65,6 +65,7 @@ impl StorageClient {
     }
 
     /// Fetch multiple page groups by key in parallel. Returns found groups.
+    #[allow(dead_code)]
     pub(crate) fn get_page_groups_by_key(&self, keys: &[String]) -> io::Result<HashMap<String, Vec<u8>>> {
         match self {
             StorageClient::Local { base_dir } => {
@@ -204,11 +205,13 @@ impl StorageClient {
     }
 
     /// Generate an interior bundle key: `p/it/{chunk_id}_v{version}`
+    #[allow(dead_code)]
     pub(crate) fn interior_chunk_key(chunk_id: u32, version: u64) -> String {
         format!("p/it/{}_v{}", chunk_id, version)
     }
 
     /// Generate an index leaf bundle key: `p/ix/{chunk_id}_v{version}`
+    #[allow(dead_code)]
     pub(crate) fn index_chunk_key(chunk_id: u32, version: u64) -> String {
         format!("p/ix/{}_v{}", chunk_id, version)
     }
@@ -221,6 +224,7 @@ impl StorageClient {
     // ── S3-specific operations (no-op for local) ──
 
     /// Byte-range GET (S3 only). Local mode reads the full file.
+    #[allow(dead_code)]
     pub(crate) fn range_get(&self, key: &str, start: u64, len: u32) -> io::Result<Option<Vec<u8>>> {
         match self {
             StorageClient::Local { base_dir } => {
@@ -243,6 +247,7 @@ impl StorageClient {
     }
 
     /// Diagnostics: number of GETs performed.
+    #[allow(dead_code)]
     pub(crate) fn fetch_count(&self) -> u64 {
         match self {
             StorageClient::Local { .. } => 0,
@@ -253,6 +258,7 @@ impl StorageClient {
     }
 
     /// Diagnostics: bytes fetched.
+    #[allow(dead_code)]
     pub(crate) fn fetch_bytes(&self) -> u64 {
         match self {
             StorageClient::Local { .. } => 0,

--- a/src/tiered/vfs.rs
+++ b/src/tiered/vfs.rs
@@ -59,6 +59,7 @@ pub struct TurboliteVfs {
     /// Tokio runtime handle for spawning WAL replication background task.
     /// None in local-only mode (no tokio dependency).
     #[cfg(feature = "cloud")]
+    #[allow(dead_code)]
     runtime_handle: Option<tokio::runtime::Handle>,
 }
 


### PR DESCRIPTION
## Summary
- `cargo fix` for 19 auto-fixable warnings (unused imports, unnecessary mut, unused variables)
- `#![allow(dead_code)]` on `prediction.rs` (experimental Jena module, 18 warnings)
- `#[allow(dead_code)]` on unused methods/fields across 12 files (APIs written ahead of use, experimental features)
- Zero warnings on `cargo check --features cloud,zstd,bundled-sqlite`

## Test plan
- [x] Zero warnings on `cargo check --features cloud,zstd,bundled-sqlite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)