### PR TITLE
feat: turbolite validate -- check database integrity against S3

### DIFF
--- a/bin/turbolite.rs
+++ b/bin/turbolite.rs
@@ -550,7 +550,7 @@ fn cmd_validate(
     let (shared, conn) = open_shared(&db, config, &vfs_name)?;
 
     println!("validating manifest...");
-    let mut result = shared.validate()
+    let result = shared.validate()
         .map_err(|e| anyhow!("validate failed: {}", e))?;
 
     println!(
@@ -596,11 +596,10 @@ fn cmd_validate(
     let integrity: String = conn
         .query_row("PRAGMA integrity_check", [], |row| row.get(0))
         .context("integrity_check failed")?;
-    result.integrity_check = Some(integrity.clone());
     println!("  integrity_check:   {}", integrity);
 
     println!();
-    if result.passed() {
+    if result.s3_ok() && integrity == "ok" {
         println!("validate: passed");
     } else {
         println!("validate: FAILED");

--- a/bin/turbolite.rs
+++ b/bin/turbolite.rs
@@ -138,6 +138,33 @@ enum Commands {
         cache_dir: PathBuf,
     },
 
+    /// Validate database integrity against S3
+    Validate {
+        /// Path to the database file
+        #[arg(long)]
+        db: PathBuf,
+
+        /// S3 bucket (required, or set TURBOLITE_BUCKET)
+        #[arg(long, env = "TURBOLITE_BUCKET")]
+        bucket: String,
+
+        /// S3 key prefix (or set TURBOLITE_PREFIX)
+        #[arg(long, env = "TURBOLITE_PREFIX")]
+        prefix: Option<String>,
+
+        /// S3 endpoint URL (or set AWS_ENDPOINT_URL)
+        #[arg(long, env = "AWS_ENDPOINT_URL")]
+        endpoint: Option<String>,
+
+        /// AWS region (or set AWS_REGION)
+        #[arg(long, env = "AWS_REGION")]
+        region: Option<String>,
+
+        /// Local cache directory
+        #[arg(long, default_value = "/tmp/turbolite-cache")]
+        cache_dir: PathBuf,
+    },
+
     /// Import a plain SQLite file into turbolite S3 format
     Import {
         /// Path to the plain SQLite file to import
@@ -510,6 +537,79 @@ fn cmd_download(
     Ok(())
 }
 
+fn cmd_validate(
+    db: PathBuf,
+    bucket: String,
+    prefix: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    cache_dir: PathBuf,
+) -> Result<()> {
+    let config = build_config(cache_dir, Some(bucket), prefix, endpoint, region, true);
+    let vfs_name = format!("turbolite-validate-{}", std::process::id());
+    let (shared, conn) = open_shared(&db, config, &vfs_name)?;
+
+    println!("validating manifest...");
+    let mut result = shared.validate()
+        .map_err(|e| anyhow!("validate failed: {}", e))?;
+
+    println!(
+        "  page groups:       {}/{} present",
+        result.page_groups_present, result.page_groups_total,
+    );
+    for key in &result.page_groups_missing {
+        println!("    MISSING: {}", key);
+    }
+
+    println!(
+        "  interior chunks:   {}/{} present",
+        result.interior_chunks_present, result.interior_chunks_total,
+    );
+    for key in &result.interior_chunks_missing {
+        println!("    MISSING: {}", key);
+    }
+
+    println!(
+        "  index chunks:      {}/{} present",
+        result.index_chunks_present, result.index_chunks_total,
+    );
+    for key in &result.index_chunks_missing {
+        println!("    MISSING: {}", key);
+    }
+
+    println!("  orphaned objects:  {}", result.orphaned_keys.len());
+    for key in &result.orphaned_keys {
+        println!("    ORPHAN: {}", key);
+    }
+
+    if !result.decode_errors.is_empty() {
+        println!("\nvalidating data...");
+        for (key, err) in &result.decode_errors {
+            println!("  DECODE ERROR: {} -- {}", key, err);
+        }
+    } else {
+        println!("\nvalidating data...");
+        println!("  page groups:       {}/{} decode ok", result.page_groups_present, result.page_groups_total);
+    }
+
+    println!("\nvalidating database...");
+    let integrity: String = conn
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .context("integrity_check failed")?;
+    result.integrity_check = Some(integrity.clone());
+    println!("  integrity_check:   {}", integrity);
+
+    println!();
+    if result.passed() {
+        println!("validate: passed");
+    } else {
+        println!("validate: FAILED");
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
 fn cmd_export(
     db: PathBuf,
     output: PathBuf,
@@ -617,6 +717,9 @@ fn main() -> Result<()> {
         }
         Commands::Download { db, bucket, prefix, endpoint, region, cache_dir, threads } => {
             cmd_download(db, bucket, prefix, endpoint, region, cache_dir, threads)?;
+        }
+        Commands::Validate { db, bucket, prefix, endpoint, region, cache_dir } => {
+            cmd_validate(db, bucket, prefix, endpoint, region, cache_dir)?;
         }
         Commands::Export { db, output, bucket, prefix, endpoint, region, cache_dir } => {
             cmd_export(db, output, bucket, prefix, endpoint, region, cache_dir)?;

--- a/src/tiered/mod.rs
+++ b/src/tiered/mod.rs
@@ -112,7 +112,8 @@ pub use settings::{turbolite_config_set, push_setting};
 #[cfg(all(feature = "encryption", feature = "cloud"))]
 pub use rotation::rotate_encryption_key;
 
-/// Result of a database validation run.
+/// Result of a database validation run (manifest + data integrity).
+/// The caller should run `PRAGMA integrity_check` separately via the connection.
 #[derive(Debug)]
 pub struct ValidateResult {
     pub manifest_version: u64,
@@ -127,16 +128,16 @@ pub struct ValidateResult {
     pub index_chunks_missing: Vec<String>,
     pub orphaned_keys: Vec<String>,
     pub decode_errors: Vec<(String, String)>,
-    pub integrity_check: Option<String>,
 }
 
 impl ValidateResult {
-    pub fn passed(&self) -> bool {
+    /// True if all S3 keys are present and all data decodes correctly.
+    /// Does NOT include SQLite integrity check (caller runs that separately).
+    pub fn s3_ok(&self) -> bool {
         self.page_groups_missing.is_empty()
             && self.interior_chunks_missing.is_empty()
             && self.index_chunks_missing.is_empty()
             && self.decode_errors.is_empty()
-            && self.integrity_check.as_deref() == Some("ok")
     }
 }
 

--- a/src/tiered/mod.rs
+++ b/src/tiered/mod.rs
@@ -112,6 +112,34 @@ pub use settings::{turbolite_config_set, push_setting};
 #[cfg(all(feature = "encryption", feature = "cloud"))]
 pub use rotation::rotate_encryption_key;
 
+/// Result of a database validation run.
+#[derive(Debug)]
+pub struct ValidateResult {
+    pub manifest_version: u64,
+    pub page_groups_total: usize,
+    pub page_groups_present: usize,
+    pub page_groups_missing: Vec<String>,
+    pub interior_chunks_total: usize,
+    pub interior_chunks_present: usize,
+    pub interior_chunks_missing: Vec<String>,
+    pub index_chunks_total: usize,
+    pub index_chunks_present: usize,
+    pub index_chunks_missing: Vec<String>,
+    pub orphaned_keys: Vec<String>,
+    pub decode_errors: Vec<(String, String)>,
+    pub integrity_check: Option<String>,
+}
+
+impl ValidateResult {
+    pub fn passed(&self) -> bool {
+        self.page_groups_missing.is_empty()
+            && self.interior_chunks_missing.is_empty()
+            && self.index_chunks_missing.is_empty()
+            && self.decode_errors.is_empty()
+            && self.integrity_check.as_deref() == Some("ok")
+    }
+}
+
 // Backward-compat type aliases (deprecated, use Turbolite* names)
 #[deprecated(note = "renamed to TurboliteVfs")]
 pub type TieredVfs = TurboliteVfs;

--- a/src/tiered/vfs.rs
+++ b/src/tiered/vfs.rs
@@ -810,7 +810,9 @@ impl TurboliteVfs {
         let page_size = manifest.page_size;
         let page_count = manifest.page_count;
         let sub_ppf = manifest.sub_pages_per_frame;
+        let encryption_key = self.config.encryption_key.as_ref();
 
+        let total_pg = manifest.page_group_keys.len();
         for (gid, key) in manifest.page_group_keys.iter().enumerate() {
             if pg_missing.contains(key) {
                 continue;
@@ -825,7 +827,7 @@ impl TurboliteVfs {
                                 if let Err(e) = decode_page_group_seekable_full(
                                     &data, ft, page_size, pages_in_group, page_count, 0,
                                     #[cfg(feature = "zstd")] None,
-                                    self.config.encryption_key.as_ref(),
+                                    encryption_key,
                                 ) {
                                     decode_errors.push((key.clone(), format!("{}", e)));
                                 }
@@ -834,7 +836,7 @@ impl TurboliteVfs {
                     } else if let Err(e) = decode_page_group(
                         &data,
                         #[cfg(feature = "zstd")] None,
-                        self.config.encryption_key.as_ref(),
+                        encryption_key,
                     ) {
                         decode_errors.push((key.clone(), format!("{}", e)));
                     }
@@ -844,6 +846,57 @@ impl TurboliteVfs {
                 }
                 Err(e) => {
                     decode_errors.push((key.clone(), format!("fetch: {}", e)));
+                }
+            }
+            if (gid + 1) % 20 == 0 || gid + 1 == total_pg {
+                eprintln!("  decoded {}/{} page groups", gid + 1, total_pg);
+            }
+        }
+
+        // Decode interior chunks
+        for (chunk_id, key) in &manifest.interior_chunk_keys {
+            if int_missing.contains(key) {
+                continue;
+            }
+            match s3.get_page_group(key) {
+                Ok(Some(data)) => {
+                    if let Err(e) = decode_interior_bundle(
+                        &data,
+                        #[cfg(feature = "zstd")] None,
+                        encryption_key,
+                    ) {
+                        decode_errors.push((key.clone(), format!("interior chunk {}: {}", chunk_id, e)));
+                    }
+                }
+                Ok(None) => {
+                    decode_errors.push((key.clone(), format!("interior chunk {}: empty", chunk_id)));
+                }
+                Err(e) => {
+                    decode_errors.push((key.clone(), format!("interior chunk {} fetch: {}", chunk_id, e)));
+                }
+            }
+        }
+
+        // Decode index chunks
+        for (chunk_id, key) in &manifest.index_chunk_keys {
+            if idx_missing.contains(key) {
+                continue;
+            }
+            match s3.get_page_group(key) {
+                Ok(Some(data)) => {
+                    if let Err(e) = decode_interior_bundle(
+                        &data,
+                        #[cfg(feature = "zstd")] None,
+                        encryption_key,
+                    ) {
+                        decode_errors.push((key.clone(), format!("index chunk {}: {}", chunk_id, e)));
+                    }
+                }
+                Ok(None) => {
+                    decode_errors.push((key.clone(), format!("index chunk {}: empty", chunk_id)));
+                }
+                Err(e) => {
+                    decode_errors.push((key.clone(), format!("index chunk {} fetch: {}", chunk_id, e)));
                 }
             }
         }
@@ -861,7 +914,6 @@ impl TurboliteVfs {
             index_chunks_missing: idx_missing,
             orphaned_keys: orphaned,
             decode_errors,
-            integrity_check: None, // caller runs PRAGMA integrity_check separately
         })
     }
 

--- a/src/tiered/vfs.rs
+++ b/src/tiered/vfs.rs
@@ -742,6 +742,129 @@ impl TurboliteVfs {
         }
     }
 
+    /// Validate the database against S3.
+    /// Checks manifest consistency (all keys present, no orphans),
+    /// data decodability (every page group decodes), and returns
+    /// results for the caller to run integrity_check separately.
+    #[cfg(feature = "cloud")]
+    pub fn validate(&self) -> io::Result<super::ValidateResult> {
+        let s3 = self.s3.as_ref().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Unsupported, "validate requires S3 backend")
+        })?;
+        let manifest = (**self.shared_manifest.load()).clone();
+        let all_keys: std::collections::HashSet<String> = s3.list_all_keys()?.into_iter().collect();
+
+        let mut live_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        // Check page group keys
+        let mut pg_missing = Vec::new();
+        for key in &manifest.page_group_keys {
+            live_keys.insert(key.clone());
+            if !all_keys.contains(key) {
+                pg_missing.push(key.clone());
+            }
+        }
+        let pg_present = manifest.page_group_keys.len() - pg_missing.len();
+
+        // Check interior chunk keys
+        let mut int_missing = Vec::new();
+        for key in manifest.interior_chunk_keys.values() {
+            live_keys.insert(key.clone());
+            if !all_keys.contains(key) {
+                int_missing.push(key.clone());
+            }
+        }
+        let int_present = manifest.interior_chunk_keys.len() - int_missing.len();
+
+        // Check index chunk keys
+        let mut idx_missing = Vec::new();
+        for key in manifest.index_chunk_keys.values() {
+            live_keys.insert(key.clone());
+            if !all_keys.contains(key) {
+                idx_missing.push(key.clone());
+            }
+        }
+        let idx_present = manifest.index_chunk_keys.len() - idx_missing.len();
+
+        // Subframe override keys are also live
+        for overrides in &manifest.subframe_overrides {
+            for ovr in overrides.values() {
+                live_keys.insert(ovr.key.clone());
+            }
+        }
+
+        // Manifest key itself
+        live_keys.insert(s3.manifest_key_msgpack());
+
+        // Snapshot manifests are also live
+        for key in &all_keys {
+            if key.contains("manifest-snap-") {
+                live_keys.insert(key.clone());
+            }
+        }
+
+        let orphaned: Vec<String> = all_keys.difference(&live_keys).cloned().collect();
+
+        // Data decode check: download and decode each present page group
+        let mut decode_errors = Vec::new();
+        let page_size = manifest.page_size;
+        let page_count = manifest.page_count;
+        let sub_ppf = manifest.sub_pages_per_frame;
+
+        for (gid, key) in manifest.page_group_keys.iter().enumerate() {
+            if pg_missing.contains(key) {
+                continue;
+            }
+            match s3.get_page_group(key) {
+                Ok(Some(data)) => {
+                    let ft = manifest.frame_tables.get(gid);
+                    let pages_in_group = manifest.group_page_nums(gid as u64).len() as u32;
+                    if sub_ppf > 0 {
+                        if let Some(ft) = ft {
+                            if !ft.is_empty() {
+                                if let Err(e) = decode_page_group_seekable_full(
+                                    &data, ft, page_size, pages_in_group, page_count, 0,
+                                    #[cfg(feature = "zstd")] None,
+                                    self.config.encryption_key.as_ref(),
+                                ) {
+                                    decode_errors.push((key.clone(), format!("{}", e)));
+                                }
+                            }
+                        }
+                    } else if let Err(e) = decode_page_group(
+                        &data,
+                        #[cfg(feature = "zstd")] None,
+                        self.config.encryption_key.as_ref(),
+                    ) {
+                        decode_errors.push((key.clone(), format!("{}", e)));
+                    }
+                }
+                Ok(None) => {
+                    decode_errors.push((key.clone(), "object returned empty".to_string()));
+                }
+                Err(e) => {
+                    decode_errors.push((key.clone(), format!("fetch: {}", e)));
+                }
+            }
+        }
+
+        Ok(super::ValidateResult {
+            manifest_version: manifest.version,
+            page_groups_total: manifest.page_group_keys.len(),
+            page_groups_present: pg_present,
+            page_groups_missing: pg_missing,
+            interior_chunks_total: manifest.interior_chunk_keys.len(),
+            interior_chunks_present: int_present,
+            interior_chunks_missing: int_missing,
+            index_chunks_total: manifest.index_chunk_keys.len(),
+            index_chunks_present: idx_present,
+            index_chunks_missing: idx_missing,
+            orphaned_keys: orphaned,
+            decode_errors,
+            integrity_check: None, // caller runs PRAGMA integrity_check separately
+        })
+    }
+
     /// Phase Recall: Copy the current manifest to a snapshot key.
     /// Returns the S3 key of the snapshot manifest copy.
     /// Called by the control plane at snapshot time to protect page groups from GC.

--- a/tests/cli_s3_test.rs
+++ b/tests/cli_s3_test.rs
@@ -345,3 +345,4 @@ fn test_validate_clean_database() {
     assert!(stdout.contains("integrity_check"), "should run integrity check");
     assert!(stdout.contains("ok"), "integrity check should be ok");
 }
+

--- a/tests/cli_s3_test.rs
+++ b/tests/cli_s3_test.rs
@@ -287,3 +287,61 @@ fn test_shell_s3_query() {
     assert!(stdout.contains("charlie"), "should contain charlie");
     assert!(stdout.contains("3"), "should show post count of 3");
 }
+
+// ── validate against S3 database ───────────────────────────────────
+
+#[test]
+fn test_validate_clean_database() {
+    build_bin();
+
+    let tmpdir = tempfile::tempdir().expect("tmpdir");
+    let plain_db = create_plain_db(tmpdir.path(), "validate-source.db");
+    let bucket = test_bucket();
+    let endpoint = endpoint_url();
+    let prefix = unique_prefix();
+
+    // Import
+    let output = run_cli(&[
+        "import",
+        "--input",
+        plain_db.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+    ]);
+    assert!(output.status.success(), "import failed for validate test");
+
+    // Validate
+    let cache_dir = tmpdir.path().join("validate-cache");
+    let db_path = tmpdir.path().join("validate.db");
+
+    let output = run_cli(&[
+        "validate",
+        "--db",
+        db_path.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+        "--cache-dir",
+        cache_dir.to_str().expect("path"),
+    ]);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "validate failed.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(stdout.contains("validate: passed"), "should pass validation");
+    assert!(stdout.contains("present"), "should show present counts");
+    assert!(stdout.contains("integrity_check"), "should run integrity check");
+    assert!(stdout.contains("ok"), "integrity check should be ok");
+}

--- a/tests/cli_s3_test.rs
+++ b/tests/cli_s3_test.rs
@@ -346,3 +346,96 @@ fn test_validate_clean_database() {
     assert!(stdout.contains("ok"), "integrity check should be ok");
 }
 
+// ── download from S3 ───────────────────────────────────────────────
+
+#[test]
+fn test_download_s3_database() {
+    build_bin();
+
+    let tmpdir = tempfile::tempdir().expect("tmpdir");
+    let plain_db = create_plain_db(tmpdir.path(), "download-source.db");
+    let bucket = test_bucket();
+    let endpoint = endpoint_url();
+    let prefix = unique_prefix();
+
+    // Import first
+    let output = run_cli(&[
+        "import",
+        "--input",
+        plain_db.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+    ]);
+    assert!(output.status.success(), "import failed for download test");
+
+    // Download entire database to local cache
+    let cache_dir = tmpdir.path().join("download-cache");
+    let db_path = tmpdir.path().join("download.db");
+
+    let output = run_cli(&[
+        "download",
+        "--db",
+        db_path.to_str().expect("path"),
+        "--bucket",
+        &bucket,
+        "--prefix",
+        &prefix,
+        "--endpoint",
+        &endpoint,
+        "--cache-dir",
+        cache_dir.to_str().expect("path"),
+    ]);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "download failed.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr,
+    );
+    assert!(stdout.contains("download:"), "should show download summary");
+    assert!(stdout.contains("tables"), "should mention tables");
+    assert!(stdout.contains("groups"), "should mention groups");
+
+    // Verify the data is queryable after download (should be cached locally)
+    let output = Command::new(turbolite_bin())
+        .args([
+            "shell",
+            "--db",
+            db_path.to_str().expect("path"),
+            "--bucket",
+            &bucket,
+            "--prefix",
+            &prefix,
+            "--endpoint",
+            &endpoint,
+            "--cache-dir",
+            cache_dir.to_str().expect("path"),
+            "--read-only",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(b"SELECT COUNT(*) FROM users;\n.quit\n")?;
+            }
+            child.wait_with_output()
+        })
+        .expect("failed to run shell after download");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("3"),
+        "should have 3 users after download.\nstdout: {}",
+        stdout,
+    );
+}
+


### PR DESCRIPTION
## Summary
Add `turbolite validate` command that checks database integrity against S3:

```
$ turbolite validate --db my.db --bucket my-bucket

validating manifest...
  page groups:       1/1 present
  interior chunks:   0/0 present
  index chunks:      0/0 present
  orphaned objects:  0

validating data...
  page groups:       1/1 decode ok

validating database...
  integrity_check:   ok

validate: passed
```

No flags, just check everything. Exit 0 on pass, exit 1 on fail.

Three phases:
1. Manifest consistency: all S3 keys exist, detect orphans
2. Data integrity: download and decode every page group
3. SQLite integrity: PRAGMA integrity_check via the VFS

Adds `ValidateResult` type and `validate()` method to public API on `TurboliteVfs`.

## Test plan
- [x] Tigris integration test: import a database, validate it, verify "passed"
- [x] Compiles clean with cloud,zstd,bundled-sqlite

🤖 Generated with [Claude Code](https://claude.com/claude-code)