### PR TITLE
feat: bundle CLI binary in pip and npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,15 @@ jobs:
           cargo build --release --lib --target ${{ matrix.target }} \
             --no-default-features --features loadable-extension,zstd,cloud,wal
 
+      - name: Build CLI binary
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+        run: |
+          cargo build --release --bin turbolite --target ${{ matrix.target }} \
+            --features cloud,zstd,bundled-sqlite
+
       - name: Determine library filename
         id: lib
         run: |
@@ -66,10 +75,13 @@ jobs:
             echo "prefix=lib" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Copy extension into Python package
+      - name: Copy extension and CLI binary into Python package
         run: |
           cp target/${{ matrix.target }}/release/${{ steps.lib.outputs.prefix }}turbolite.${{ steps.lib.outputs.ext }} \
             packages/python/turbolite/turbolite.${{ steps.lib.outputs.ext }}
+          cp target/${{ matrix.target }}/release/turbolite \
+            packages/python/turbolite/turbolite
+          chmod +x packages/python/turbolite/turbolite
 
       - uses: actions/setup-python@v5
         with:
@@ -161,10 +173,23 @@ jobs:
           CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
         run: npx @napi-rs/cli build --release --platform --target ${{ matrix.target }}
 
+      - name: Build CLI binary for Node package
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+        run: |
+          cargo build --release --bin turbolite --target ${{ matrix.target }} \
+            --features cloud,zstd,bundled-sqlite
+          cp target/${{ matrix.target }}/release/turbolite packages/node/turbolite
+          chmod +x packages/node/turbolite
+
       - uses: actions/upload-artifact@v4
         with:
           name: node-${{ matrix.node-arch }}
-          path: packages/node/turbolite.*.node
+          path: |
+            packages/node/turbolite.*.node
+            packages/node/turbolite
 
   node-publish:
     needs: node-build

--- a/packages/node/bin/turbolite.js
+++ b/packages/node/bin/turbolite.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const platform = process.platform;
+const arch = process.arch;
+
+// Map Node platform/arch to binary name
+const ext = platform === "win32" ? ".exe" : "";
+const binaryName = `turbolite${ext}`;
+const binaryPath = path.join(__dirname, "..", binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error(
+    `turbolite CLI binary not found at ${binaryPath}.\n` +
+      `Ensure the package was installed with the platform-specific binary.`
+  );
+  process.exit(1);
+}
+
+try {
+  execFileSync(binaryPath, process.argv.slice(2), { stdio: "inherit" });
+} catch (e) {
+  if (e.status != null) {
+    process.exit(e.status);
+  }
+  throw e;
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,10 +4,16 @@
   "description": "Compressed SQLite — transparent zstd compression via a custom VFS",
   "main": "index.js",
   "types": "index.d.ts",
+  "bin": {
+    "turbolite": "bin/turbolite.js"
+  },
   "files": [
     "index.js",
     "index.d.ts",
-    "turbolite.*.node"
+    "turbolite.*.node",
+    "bin/turbolite.js",
+    "turbolite",
+    "turbolite.exe"
   ],
   "napi": {
     "name": "turbolite",

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -16,8 +16,11 @@ classifiers = [
     "Topic :: Database",
 ]
 
+[project.scripts]
+turbolite = "turbolite.cli:main"
+
 [tool.setuptools.packages.find]
 include = ["turbolite*"]
 
 [tool.setuptools.package-data]
-turbolite = ["*.so", "*.dylib"]
+turbolite = ["*.so", "*.dylib", "turbolite", "turbolite.exe"]

--- a/packages/python/turbolite/cli.py
+++ b/packages/python/turbolite/cli.py
@@ -1,0 +1,37 @@
+"""Entry point for the turbolite CLI binary bundled in the wheel."""
+
+import os
+import platform
+import subprocess
+import sys
+
+
+def _find_binary() -> str:
+    """Find the bundled turbolite CLI binary."""
+    pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    system = platform.system()
+
+    if system == "Windows":
+        name = "turbolite.exe"
+    else:
+        name = "turbolite"
+
+    path = os.path.join(pkg_dir, name)
+    if os.path.isfile(path):
+        return path
+
+    raise FileNotFoundError(
+        f"turbolite CLI binary not found at {path}. "
+        "Ensure the package was installed with the platform-specific binary."
+    )
+
+
+def main():
+    """Run the turbolite CLI binary, passing through all args."""
+    try:
+        binary = _find_binary()
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    os.execv(binary, [binary] + sys.argv[1:])


### PR DESCRIPTION
## Summary
`pip install turbolite` and `npm install turbolite` now install the CLI binary alongside the language APIs.

### Python
- Thin `turbolite/cli.py` wrapper that finds and exec's the bundled binary
- Console script entry point: `turbolite = "turbolite.cli:main"`
- Binary bundled as package data alongside the .so/.dylib

### Node
- `bin/turbolite.js` wrapper that finds and execFileSync's the binary
- `bin` field in package.json
- Binary included in `files` list

### Release CI
- Both Python and Node build jobs now also build the CLI binary (`--features cloud,zstd,bundled-sqlite`) and copy it into the package directory before wheel/npm packaging

## Test plan
- [x] Local test: `pip install -e packages/python` then `turbolite --version` works
- [x] Local test: `python -c "import turbolite"` still works
- [x] Release CI builds the binary for all platforms (linux x64/arm64, macos x64/arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)