### PR TITLE
Make Turbolite bindings file-first; fix sync=OFF persistence regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,14 +416,18 @@ make lib-bundled  # build libturbolite.{so,dylib}
 ```go
 // #cgo LDFLAGS: -L/path/to/target/release -lturbolite
 // #include <stdlib.h>
-// extern int turbolite_register_local(const char* name, const char* cache_dir, int level);
+// extern int turbolite_register_local_file_first(const char* name, const char* db_path, int level);
 // extern void* turbolite_open(const char* path, const char* vfs_name);
 // extern int turbolite_exec(void* db, const char* sql);
 // extern char* turbolite_query_json(void* db, const char* sql);
 // extern void turbolite_close(void* db);
 import "C"
 ```
-See [examples/go/](examples/go/) for a full HTTP server example.
+The recommended `turbolite_register_local_file_first(name, db_path, level)` is keyed
+on the user-facing database path. The lower-level
+`turbolite_register_local(name, cache_dir, level)` is still exported for
+embedders that want to manage the cache directory themselves. See
+[examples/go/](examples/go/) for a full HTTP server example.
 
 ### Loadable extension (any language)
 
@@ -439,7 +443,21 @@ sqlite3_enable_load_extension(db, 1);
 sqlite3_load_extension(db, "path/to/turbolite", NULL, NULL);
 // "turbolite" VFS (local) is always registered
 // "turbolite-s3" VFS is also registered if TURBOLITE_BUCKET is set
-``` 
+```
+
+For the file-first user story, register a per-database VFS that owns the
+caller's `app.db`:
+
+```sql
+SELECT turbolite_register_file_first_vfs('app', '/data/app.db');
+-- now open /data/app.db via vfs=app; turbolite stores its sidecar
+-- metadata at /data/app.db-turbolite/.
+```
+
+To configure the default `"turbolite"` VFS for file-first mode at extension
+load time, set `TURBOLITE_DATABASE_PATH=/data/app.db` in the environment
+before loading the extension. The sidecar is then `/data/app.db-turbolite/`
+and the lower-level `TURBOLITE_CACHE_DIR` knob is ignored.
 
 ### Node.js
 
@@ -448,37 +466,54 @@ npm install turbolite
 ```
 
 ```js
-const { Database } = require("turbolite");
+const { connect } = require("turbolite");
 
-const db = new Database("my.db");
+// File-first: /data/app.db is the local page image.
+// /data/app.db-turbolite/ holds hidden implementation state.
+const db = connect("/data/app.db");
 db.exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)");
-db.exec("INSERT INTO users VALUES (1, 'alice')");
+db.prepare("INSERT INTO users VALUES (?, ?)").run(1, 'alice');
 
-const rows = db.query("SELECT * FROM users");
+const rows = db.prepare("SELECT id, name FROM users").all();
 // [{ id: 1, name: 'alice' }]
 db.close();
 ```
 
-Note: Node uses a wrapped `Database` class (not `load_extension`) because better-sqlite3 compiles with `SQLITE_USE_URI=0`. See [turbolite-ffi/packages/node/](turbolite-ffi/packages/node/) for full docs.
+`db` is a standard better-sqlite3 Database. `connect()` registers a
+per-database file-first VFS for you. To export a stock SQLite file (for
+example to inspect with the `sqlite3` CLI), use the better-sqlite3 backup
+API: `await db.backup('export.sqlite')`. See
+[turbolite-ffi/packages/node/](turbolite-ffi/packages/node/) for full docs.
 
-### Rust (local)
+### Rust (local, file-first)
 
 ```rust
 use turbolite::tiered::{TurboliteVfs, TurboliteConfig};
 
-let config = TurboliteConfig {
-    cache_dir: "/path/to/data".into(),
-    ..Default::default()
-};
-let vfs = TurboliteVfs::new(config)?;
+// `app.db` is the user-visible local page image.
+// `app.db-turbolite/` holds hidden implementation state.
+let config = TurboliteConfig::for_database_path("/data/app.db");
+let vfs = TurboliteVfs::new_local(config)?;
 turbolite::tiered::register("turbolite", vfs)?;
 
 let conn = rusqlite::Connection::open_with_flags_and_vfs(
-    "mydb.db",
+    "/data/app.db",
     rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_CREATE,
     "turbolite",
 )?;
 ```
+
+The lower-level form lets you pick the cache directory directly:
+
+```rust
+let config = TurboliteConfig {
+    cache_dir: "/path/to/data".into(),  // turbolite owns this dir
+    ..Default::default()
+};
+```
+
+In that case the local image is `/path/to/data/data.cache` rather than a
+caller-named `app.db`. New embedders should prefer the file-first form.
 
 ### Rust (S3 cloud)
 
@@ -486,20 +521,22 @@ let conn = rusqlite::Connection::open_with_flags_and_vfs(
 use turbolite::tiered::{TurboliteVfs, TurboliteConfig};
 use hadb_storage::StorageBackend;
 
-let config = TurboliteConfig {
-    cache_dir: "/tmp/cache".into(),
-    ..Default::default()
-};
+let config = TurboliteConfig::for_database_path("/data/app.db");
 let storage: Arc<dyn StorageBackend> = /* your S3 backend */;
 let vfs = TurboliteVfs::with_backend(config, storage, tokio::runtime::Handle::current())?;
 turbolite::tiered::register("turbolite", vfs)?;
 
 let conn = rusqlite::Connection::open_with_flags_and_vfs(
-    "mydb.db",
+    "/data/app.db",
     rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_CREATE,
     "turbolite",
 )?;
 ```
+
+`app.db` is turbolite's compressed page image. It is not promised to be
+opened directly by stock `sqlite3`. For a normal SQLite file (e.g. for the
+`sqlite3` CLI), use the SQLite online backup API or the binding-specific
+export helper (`conn.iterdump()` in Python, `db.backup()` in Node).
 
 ## CLI
 

--- a/examples/c/README.md
+++ b/examples/c/README.md
@@ -21,7 +21,15 @@ Simulate an IoT sensor logger: generate 10 temperature readings, store them in a
 ## How it works
 
 1. `#include "turbolite.h"` - auto-generated C header from `make header`
-2. `turbolite_register_local` (local) or `turbolite_register_cloud` (S3)
+2. `turbolite_register_local_file_first` (local file-first) or
+   `turbolite_register_cloud` (S3). The lower-level
+   `turbolite_register_local(name, cache_dir, level)` is also available
+   when you want turbolite to own a directory and store the local image
+   at `<cache_dir>/data.cache`.
 3. `turbolite_open` - open a database through the VFS
 4. `turbolite_exec` - insert sensor readings
 5. `turbolite_query_json` - query aggregates, get JSON back
+
+In file-first mode the user-supplied database path (`sensors.db` in
+the example) is the local page image. Hidden implementation state lives
+next to it under `sensors.db-turbolite/`.

--- a/examples/c/local.c
+++ b/examples/c/local.c
@@ -34,12 +34,19 @@ int main(void) {
     printf("turbolite %s — sensor logger\n", turbolite_version());
     printf("Data dir: %s\n\n", data_dir);
 
-    /* Register VFS and open database */
-    if (turbolite_register_local("sensor", data_dir, 3) != 0)
-        die("register VFS");
-
+    /*
+     * File-first registration: the caller's database path is the local
+     * page image. Sidecar metadata lives at `<db_path>-turbolite/`.
+     *
+     * To export a stock SQLite file from this database, run:
+     *   turbolite_exec(db, "VACUUM INTO '/tmp/exported.sqlite'");
+     * The exported file opens with the standard sqlite3 CLI.
+     */
     char db_path[512];
     snprintf(db_path, sizeof(db_path), "%s/sensors.db", data_dir);
+
+    if (turbolite_register_local_file_first("sensor", db_path, 3) != 0)
+        die("register VFS");
 
     void *db = turbolite_open(db_path, "sensor");
     if (!db) die("open database");

--- a/examples/go/local.go
+++ b/examples/go/local.go
@@ -20,7 +20,7 @@ package main
 
 extern const char* turbolite_version();
 extern const char* turbolite_last_error();
-extern int turbolite_register_local(const char* name, const char* base_dir, int level);
+extern int turbolite_register_local_file_first(const char* name, const char* db_path, int level);
 extern void* turbolite_open(const char* path, const char* vfs_name);
 extern int turbolite_exec(void* db, const char* sql);
 extern char* turbolite_query_json(void* db, const char* sql);
@@ -67,14 +67,17 @@ func main() {
 	dataDir, _ := os.MkdirTemp("", "turbolite-example-")
 	defer os.RemoveAll(dataDir)
 
+	// File-first local registration: the user-supplied path is the local
+	// page image. Sidecar metadata lives at "books.db-turbolite/" beside
+	// it. To get a stock SQLite file, run
+	//   exec("VACUUM INTO 'books-export.sqlite'")
+	// while connected through turbolite.
 	name := cstr("demo")
 	defer C.free(unsafe.Pointer(name))
-	base := cstr(dataDir)
-	defer C.free(unsafe.Pointer(base))
-	C.turbolite_register_local(name, base, 3)
-
 	dbPath := cstr(filepath.Join(dataDir, "books.db"))
 	defer C.free(unsafe.Pointer(dbPath))
+	C.turbolite_register_local_file_first(name, dbPath, 3)
+
 	db = C.turbolite_open(dbPath, name)
 	defer C.turbolite_close(db)
 

--- a/examples/node/local.mjs
+++ b/examples/node/local.mjs
@@ -16,7 +16,7 @@
  *   curl localhost:3000/books
  */
 
-import { Database } from "turbolite";
+import { connect } from "turbolite";
 import http from "http";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
@@ -25,7 +25,15 @@ import { join } from "path";
 // ── Set up database ─────────────────────────────────────────────────
 
 const dataDir = mkdtempSync(join(tmpdir(), "turbolite-example-"));
-const db = new Database(join(dataDir, "books.db"));
+const dbPath = join(dataDir, "books.db");
+// File-first local mode (the default): the user-visible artifact is
+// `books.db`. Hidden implementation state (manifest, cache, staging logs)
+// lives next to it at `books.db-turbolite/`.
+//
+// `books.db` is turbolite's compressed page image. It is not promised to
+// be opened by stock sqlite3. To get a normal SQLite file the standard
+// CLI can read, run `db.exec("VACUUM INTO 'books-export.sqlite'")`.
+const db = connect(dbPath);
 
 db.exec(`
   CREATE TABLE books (
@@ -37,21 +45,23 @@ db.exec(`
 
 // ── HTTP server ─────────────────────────────────────────────────────
 
+const listAll = db.prepare("SELECT * FROM books ORDER BY year");
+const insertBook = db.prepare("INSERT INTO books (title, year) VALUES (?, ?)");
+const lastBook = db.prepare("SELECT * FROM books ORDER BY id DESC LIMIT 1");
+
 const server = http.createServer((req, res) => {
   if (req.method === "GET" && req.url === "/books") {
-    const rows = db.query("SELECT * FROM books ORDER BY year");
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(rows));
+    res.end(JSON.stringify(listAll.all()));
 
   } else if (req.method === "POST" && req.url === "/books") {
     let body = "";
     req.on("data", (c) => (body += c));
     req.on("end", () => {
       const { title, year } = JSON.parse(body);
-      db.exec(`INSERT INTO books (title, year) VALUES ('${title}', ${year})`);
-      const rows = db.query("SELECT * FROM books ORDER BY id DESC LIMIT 1");
+      insertBook.run(title, year);
       res.writeHead(201, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(rows[0]));
+      res.end(JSON.stringify(lastBook.get()));
     });
 
   } else {

--- a/examples/python/local.py
+++ b/examples/python/local.py
@@ -33,7 +33,13 @@ from pydantic import BaseModel
 data_dir = tempfile.mkdtemp(prefix="turbolite-example-")
 db_path = os.path.join(data_dir, "books.db")
 
-# Local compressed database (mode="local" is the default)
+# File-first local mode (the default): the user-visible database file is
+# `books.db`. turbolite stores its hidden implementation state next to it,
+# at `books.db-turbolite/` (manifest, cache, staging logs).
+#
+# `books.db` is turbolite's compressed page image. To get a stock SQLite
+# file that the standard sqlite3 CLI can open, run
+# `conn.execute("VACUUM INTO 'books-export.sqlite'")` while connected.
 conn = turbolite.connect(db_path)
 
 conn.execute("""

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,6 +1,6 @@
 # turbolite
 
-SQLite for Node.js with compressed page groups and optional S3 cloud storage. Transparent zstd compression via TurboliteVfs.
+SQLite for Node.js with compressed page groups and optional S3 cloud storage. Returns standard **better-sqlite3** connections with full API: prepared statements, param binding, transactions, user-defined functions, aggregates, and more.
 
 ## Install
 
@@ -8,122 +8,145 @@ SQLite for Node.js with compressed page groups and optional S3 cloud storage. Tr
 npm install turbolite
 ```
 
+The postinstall script patches better-sqlite3 to enable URI filename support (`SQLITE_USE_URI=1`) and rebuilds from source. This is required for VFS selection via URI.
+
 ## Usage
 
-### Local mode (compressed)
+### Local mode (compressed, file-first)
 
 ```js
-import { Database } from "turbolite";
+const turbolite = require('turbolite');
 
-const db = new Database("my.db");
+// /data/app.db is the user-visible local page image (turbolite-owned).
+// /data/app.db-turbolite/ holds hidden implementation state
+// (manifest, cache, staging logs).
+const db = turbolite.connect('/data/app.db');
 
-db.exec(`
-  CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER);
-  INSERT INTO users VALUES (1, 'alice', 30);
-  INSERT INTO users VALUES (2, 'bob', 25);
-`);
+// Full better-sqlite3 API: prepared statements, param binding, transactions
+const insert = db.prepare('INSERT INTO users (name, age) VALUES (?, ?)');
+insert.run('alice', 30);
+insert.run('bob', 25);
 
-const rows = db.query("SELECT * FROM users WHERE age > 20");
+const rows = db.prepare('SELECT * FROM users WHERE age > ?').all(20);
 // [{ id: 1, name: 'alice', age: 30 }, { id: 2, name: 'bob', age: 25 }]
+
+// Transactions
+const batchInsert = db.transaction((users) => {
+  for (const u of users) insert.run(u.name, u.age);
+});
+batchInsert([{ name: 'charlie', age: 35 }]);
 
 db.close();
 ```
 
-### S3 cloud mode
-
-Pages are compressed locally and durably synced to S3 (or any S3-compatible store). Any instance with access to the same bucket can read the database.
+`app.db` is turbolite's compressed page image. It is not promised to be
+opened directly by stock SQLite. To produce a normal SQLite file the
+`sqlite3` CLI can read, use better-sqlite3's online backup API:
 
 ```js
-import { Database } from "turbolite";
+await db.backup('/data/exported.sqlite');
+```
 
-const db = new Database("my.db", {
-  mode: "s3",
-  bucket: "my-bucket",
-  region: "us-east-1",
+(`db.backup` opens the destination via SQLite's default VFS, sidestepping
+the file-first VFS's identity check on alias opens.)
+
+### S3 cloud mode
+
+Pages are compressed locally and durably synced to S3 (or any S3-compatible store).
+
+```js
+const db = turbolite.connect('my.db', {
+  mode: 's3',
+  bucket: 'my-bucket',
+  region: 'us-east-1',
 });
 ```
 
 With a custom S3-compatible endpoint (Tigris, MinIO, etc.):
 
 ```js
-const db = new Database("my.db", {
-  mode: "s3",
-  bucket: "my-bucket",
-  endpoint: "https://fly.storage.tigris.dev",
-  region: "auto",
+const db = turbolite.connect('my.db', {
+  mode: 's3',
+  bucket: 'my-bucket',
+  endpoint: 'https://fly.storage.tigris.dev',
+  region: 'auto',
 });
 ```
 
-AWS credentials are read from the standard chain: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, `~/.aws/credentials`, or instance metadata.
-
 ## API
 
-### `new Database(path, options?)`
+### `turbolite.connect(path, options?)`
 
-Open a database.
+Open a database. Returns a standard `better-sqlite3.Database`.
 
-- **path** `string` — Path to the database file.
-- **options** `object` — Optional. Defaults to local compressed mode.
+- **path** `string` -- Path to the database file.
+- **options** `object` -- Optional. Defaults to local compressed mode.
 
-#### Local mode options
-
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `compression` | `number \| null` | `null` | zstd compression level 1–22. `null` for no compression. |
-
-```js
-// zstd level 9
-const db = new Database("my.db", { compression: 9 });
-
-// No compression
-const db = new Database("my.db", { compression: null });
-```
-
-#### S3 cloud mode options
-
-Set `mode: "s3"` to enable S3 cloud storage.
+#### Options
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `mode` | `"s3"` | — | Enables S3 cloud storage. |
-| `bucket` | `string` | — | **Required.** S3 bucket name. Also read from `TURBOLITE_BUCKET`. |
-| `region` | `string` | SDK default | AWS region (e.g. `"us-east-1"`). Also read from `TURBOLITE_REGION`. |
-| `endpoint` | `string` | AWS S3 | Custom S3 endpoint URL. Also read from `TURBOLITE_ENDPOINT_URL`. |
-| `prefix` | `string` | `"turbolite"` | S3 key prefix for all stored objects. |
-| `cache_dir` | `string` | db file's directory | Local directory for the page cache. |
+| `mode` | `'local' \| 's3'` | `'local'` | Storage mode. |
+| `bucket` | `string` | -- | S3 bucket name (required for `mode='s3'`). |
+| `endpoint` | `string` | AWS S3 | Custom S3 endpoint URL. |
+| `prefix` | `string` | `'turbolite'` | S3 key prefix. |
+| `region` | `string` | SDK default | AWS region. |
+| `cacheDir` | `string` | -- | Lower-level: override the sidecar location (default is `<dbPath>-turbolite`). Mostly useful in S3 mode. |
+| `compressionLevel` | `number` | `3` | Zstd compression level 1-22. |
+| `readOnly` | `boolean` | `false` | Open in read-only mode. |
+| `pageCache` | `string` | `'64MB'` | In-memory page cache size. Set to `'0'` to disable. |
 
-**Note:** For AWS S3 Express One Zone buckets (names ending in `--x-s3`), omit `endpoint` — the SDK autodiscovers the correct zone endpoint from the bucket name.
+### `turbolite.load(db)`
 
-### `db.exec(sql)`
+Load the turbolite extension into an existing better-sqlite3 Database.
 
-Execute SQL that returns no rows (DDL, INSERT, UPDATE, DELETE).
+### `turbolite.stateDirForDatabasePath(dbPath)`
 
-### `db.query(sql)`
+Return the hidden sidecar directory path for a file-first database path.
+For `/data/app.db` this is `/data/app.db-turbolite`. Useful for tests or
+tooling that asserts on layout without hardcoding the suffix rule.
 
-Execute a SELECT and return rows as an array of plain objects.
+## Architecture
 
-### `db.close()`
+Each `connect()` call creates an isolated VFS instance keyed to the
+caller's database path. The user-supplied path is the local page image;
+hidden implementation state lives at `<dbPath>-turbolite/`.
 
-Close the database connection.
+Under the hood:
+1. The turbolite loadable extension is loaded into better-sqlite3's SQLite
+2. `turbolite_register_file_first_vfs(name, dbPath)` creates a named VFS
+   instance bound to that path
+3. The database is opened via URI: `file:dbPath?vfs=turbolite-node-N`
+4. `PRAGMA cache_size=0` disables SQLite's cache (turbolite manages its own)
 
-## Environment variables
-
-| Variable | Description |
-|---|---|
-| `TURBOLITE_BUCKET` | S3 bucket name (S3 mode) |
-| `TURBOLITE_REGION` | AWS region (S3 mode) |
-| `TURBOLITE_ENDPOINT_URL` | Custom S3 endpoint URL (S3 mode) |
-| `AWS_ACCESS_KEY_ID` | AWS credentials |
-| `AWS_SECRET_ACCESS_KEY` | AWS credentials |
-
-## Why a wrapped Database class?
-
-Node can't use `sqlite3.load_extension()` with better-sqlite3 (compiled with `SQLITE_USE_URI=0`), preventing VFS selection via URI. The wrapped `Database` class embeds SQLite with the VFS pre-registered.
+The lower-level `turbolite_register_vfs(name, cacheDir)` SQL function is
+still available for embedders that want turbolite to own a directory and
+store the local image at `<cacheDir>/data.cache`. New code should prefer
+the file-first form.
 
 ## Build from source
 
 ```bash
 cd packages/node
+
+# Build the loadable extension (requires Rust)
+npm run build-ext
+
+# Install dependencies (patches + rebuilds better-sqlite3 for URI support)
 npm install
-npx @napi-rs/cli build --release --platform
+
+# Run tests
+npm test
 ```
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `TURBOLITE_EXT_PATH` | Override path to the loadable extension binary |
+| `TURBOLITE_DATABASE_PATH` | File-first database path for the default `"turbolite"` VFS (extension-load time) |
+| `TURBOLITE_BUCKET` | S3 bucket name (S3 mode) |
+| `TURBOLITE_REGION` | AWS region (S3 mode) |
+| `TURBOLITE_ENDPOINT_URL` | Custom S3 endpoint URL (S3 mode) |
+| `TURBOLITE_MEM_CACHE_BUDGET` | Page cache size (default `64MB`) |
+| `TURBOLITE_COMPRESSION_LEVEL` | Zstd level 1-22 (default `3`) |

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -11,16 +11,12 @@ pip install turbolite
 ## Usage
 
 ```python
-import sqlite3
 import turbolite
 
-# Load the extension (registers the "turbolite" VFS process-wide)
-conn = sqlite3.connect(":memory:")
-turbolite.load(conn)
-conn.close()
-
-# Open a compressed database
-conn = sqlite3.connect("file:my.db?vfs=turbolite", uri=True)
+# File-first: /data/app.db is the local page image (turbolite-owned).
+# /data/app.db-turbolite/ holds hidden implementation state
+# (manifest, cache, staging logs).
+conn = turbolite.connect("/data/app.db")
 conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
 conn.execute("INSERT INTO users VALUES (1, 'alice')")
 conn.commit()
@@ -30,16 +26,27 @@ print(rows)  # [(1, 'alice')]
 conn.close()
 ```
 
-### Convenience wrapper
+`app.db` is turbolite's compressed page image. It is not promised to be
+opened directly by stock `sqlite3`. To produce a normal SQLite file the
+standard `sqlite3` CLI can read, use `iterdump`:
 
 ```python
-import turbolite
-
-conn = turbolite.connect("my.db")
-conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")
-conn.commit()
-conn.close()
+src = turbolite.connect("/data/app.db")
+dst = sqlite3.connect("/data/exported.sqlite")
+dst.executescript("\n".join(src.iterdump()))
+dst.close()
+src.close()
 ```
+
+### Lower-level entry point
+
+If you need direct access to the SQLite extension (e.g. to register
+multiple per-tenant VFSes from a single connection), call
+`turbolite.load(conn)` and use the `turbolite_register_file_first_vfs(name,
+db_path)` SQL function yourself. The bare `cache_dir`-based
+`turbolite_register_vfs(name, cache_dir)` is still available for embedders
+who want to manage the cache layout directly, but new code should use
+`turbolite.connect()` or the file-first SQL function.
 
 ### SQL functions
 

--- a/packages/python/test_turbolite.py
+++ b/packages/python/test_turbolite.py
@@ -94,6 +94,21 @@ def test_local_relative_path():
     print("  PASS")
 
 
+def test_local_rejects_nonexistent_parent_dir():
+    """connect() must surface a clear error when the parent directory
+    doesn't exist, instead of producing a confusing SQLite error from
+    inside the VFS."""
+    print("test: file-first rejects nonexistent parent dir...")
+    bogus = "/this-path-does-not-exist-12345/app.db"
+    raised = False
+    try:
+        turbolite.connect(bogus)
+    except FileNotFoundError as e:
+        raised = "directory does not exist" in str(e)
+    assert raised, "must raise FileNotFoundError for missing parent dir"
+    print("  PASS")
+
+
 def test_local_two_databases_isolated():
     """Local mode: two app.db files in different directories get distinct
     sidecars and do not share manifest state."""
@@ -238,6 +253,7 @@ if __name__ == "__main__":
     test_local_basic_crud()
     test_local_file_first_layout()
     test_local_relative_path()
+    test_local_rejects_nonexistent_parent_dir()
     test_local_two_databases_isolated()
     test_local_export_to_stock_sqlite()
     test_s3_requires_bucket()

--- a/packages/python/test_turbolite.py
+++ b/packages/python/test_turbolite.py
@@ -25,6 +25,145 @@ def test_local_basic_crud():
     print("  PASS")
 
 
+def test_local_file_first_layout():
+    """Local mode: app.db is the user-visible artifact and the sidecar lives
+    at app.db-turbolite/local_state.msgpack — old split tracking files are
+    not produced or required."""
+    print("test: file-first layout...")
+    with tempfile.TemporaryDirectory() as d:
+        db_path = os.path.join(d, "app.db")
+        conn = turbolite.connect(db_path)
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")
+        conn.execute("INSERT INTO t VALUES (1, 'one')")
+        conn.execute("INSERT INTO t VALUES (2, 'two')")
+        conn.commit()
+        conn.close()
+
+        assert os.path.isfile(db_path), \
+            f"file-first: {db_path} must exist after close"
+
+        sidecar = turbolite.state_dir_for_database_path(db_path)
+        assert sidecar == db_path + "-turbolite"
+        assert os.path.isdir(sidecar), \
+            f"file-first: sidecar dir {sidecar} must exist"
+
+        # The consolidated local-state file is the one promised name.
+        local_state = os.path.join(sidecar, "local_state.msgpack")
+        assert os.path.isfile(local_state), (
+            f"file-first: {local_state} must exist; the file-first contract "
+            f"is one consolidated local-state file, not split tracking files."
+        )
+
+        # The pre-PR-#27 split DiskCache tracking files must not be produced.
+        # In pure-local mode the local backend still writes its own
+        # `manifest.msgpack` under the sidecar; that is a different
+        # conceptual artifact (backend manifest vs. legacy local-cache
+        # tracking) and is expected.
+        for legacy in ("page_bitmap", "sub_chunk_tracker",
+                       "cache_index.json", "dirty_groups.msgpack"):
+            assert not os.path.isfile(os.path.join(sidecar, legacy)), (
+                f"file-first: legacy split file {legacy} should not be "
+                f"produced"
+            )
+
+        # Reopen and re-read the data.
+        conn = turbolite.connect(db_path)
+        rows = conn.execute("SELECT * FROM t ORDER BY id").fetchall()
+        assert rows == [(1, "one"), (2, "two")]
+        conn.close()
+    print("  PASS")
+
+
+def test_local_relative_path():
+    """Local mode: connect resolves relative paths and lays the sidecar
+    next to the resolved absolute path, not next to whatever cwd was."""
+    print("test: file-first relative path...")
+    with tempfile.TemporaryDirectory() as d:
+        cwd = os.getcwd()
+        try:
+            os.chdir(d)
+            conn = turbolite.connect("app.db")
+            conn.execute("CREATE TABLE t (id INTEGER)")
+            conn.execute("INSERT INTO t VALUES (42)")
+            conn.commit()
+            conn.close()
+            assert os.path.isfile(os.path.join(d, "app.db"))
+            assert os.path.isdir(os.path.join(d, "app.db-turbolite"))
+        finally:
+            os.chdir(cwd)
+    print("  PASS")
+
+
+def test_local_two_databases_isolated():
+    """Local mode: two app.db files in different directories get distinct
+    sidecars and do not share manifest state."""
+    print("test: two file-first databases isolated...")
+    with tempfile.TemporaryDirectory() as d:
+        a = os.path.join(d, "a")
+        b = os.path.join(d, "b")
+        os.makedirs(a)
+        os.makedirs(b)
+
+        conn_a = turbolite.connect(os.path.join(a, "app.db"))
+        conn_a.execute("CREATE TABLE t (v TEXT)")
+        conn_a.execute("INSERT INTO t VALUES ('from-a')")
+        conn_a.commit()
+        conn_a.close()
+
+        conn_b = turbolite.connect(os.path.join(b, "app.db"))
+        conn_b.execute("CREATE TABLE t (v TEXT)")
+        conn_b.execute("INSERT INTO t VALUES ('from-b')")
+        conn_b.commit()
+        conn_b.close()
+
+        assert os.path.isdir(os.path.join(a, "app.db-turbolite"))
+        assert os.path.isdir(os.path.join(b, "app.db-turbolite"))
+
+        conn_a = turbolite.connect(os.path.join(a, "app.db"))
+        assert conn_a.execute("SELECT v FROM t").fetchone() == ("from-a",)
+        conn_a.close()
+
+        conn_b = turbolite.connect(os.path.join(b, "app.db"))
+        assert conn_b.execute("SELECT v FROM t").fetchone() == ("from-b",)
+        conn_b.close()
+    print("  PASS")
+
+
+def test_local_export_to_stock_sqlite():
+    """Local mode: iterdump replays through stock sqlite3 to produce a
+    file the standard sqlite3 CLI can open. This is the supported export
+    path; ``VACUUM INTO`` is not — file-first VFS rejects mismatched
+    target paths to keep the local image identity sound."""
+    print("test: file-first export to stock SQLite via iterdump...")
+    with tempfile.TemporaryDirectory() as d:
+        db_path = os.path.join(d, "app.db")
+        export_path = os.path.join(d, "exported.sqlite")
+
+        conn = turbolite.connect(db_path)
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.execute("INSERT INTO t VALUES (1, 'alpha')")
+        conn.execute("INSERT INTO t VALUES (2, 'beta')")
+        conn.commit()
+
+        # iterdump emits its own BEGIN/COMMIT around DDL+DML; replay it as
+        # one script so executescript()'s auto-commit doesn't fight it.
+        dump = "\n".join(conn.iterdump())
+        plain = sqlite3.connect(export_path)
+        try:
+            plain.executescript(dump)
+        finally:
+            plain.close()
+        conn.close()
+
+        assert os.path.isfile(export_path)
+        # Stock sqlite3 (no turbolite VFS) opens the export.
+        plain = sqlite3.connect(export_path)
+        rows = plain.execute("SELECT id, name FROM t ORDER BY id").fetchall()
+        assert rows == [(1, "alpha"), (2, "beta")]
+        plain.close()
+    print("  PASS")
+
+
 def test_s3_write_read():
     """S3 mode: write, checkpoint, verify page_size and WAL."""
     bucket = os.environ.get("TIERED_TEST_BUCKET") or os.environ.get("TURBOLITE_BUCKET")
@@ -97,5 +236,9 @@ if __name__ == "__main__":
     # turbolite-s3. Local mode works regardless of load order.
     test_s3_write_read()
     test_local_basic_crud()
+    test_local_file_first_layout()
+    test_local_relative_path()
+    test_local_two_databases_isolated()
+    test_local_export_to_stock_sqlite()
     test_s3_requires_bucket()
     print("\nAll tests passed!")

--- a/packages/python/turbolite/__init__.py
+++ b/packages/python/turbolite/__init__.py
@@ -1,26 +1,40 @@
 """
 turbolite -- SQLite with compressed page groups and optional S3 cloud storage for Python.
 
-Local mode (default)::
+Local mode (default), file-first::
 
     import turbolite
-    conn = turbolite.connect("my.db")
+    conn = turbolite.connect("/data/app.db")
+    # /data/app.db is the local page image (turbolite-owned).
+    # /data/app.db-turbolite/ holds hidden implementation state
+    # (manifest, cache, staging logs).
 
 S3 cloud mode::
 
-    conn = turbolite.connect("my.db", mode="s3",
+    conn = turbolite.connect("/data/app.db", mode="s3",
         bucket="my-bucket",
         endpoint="https://t3.storage.dev")
+
+Note: ``app.db`` is turbolite's compressed page image. It is not promised
+to be opened directly by stock ``sqlite3``. To get a stock SQLite file,
+use ``conn.iterdump()`` or ``VACUUM INTO`` while connected via turbolite.
 """
 
 from __future__ import annotations
 
+import itertools
 import os
 import platform
 import sqlite3
 import sys
 
 __version__ = "0.4.1"
+
+
+# Per-database VFS counter used to keep file-first registrations isolated.
+# Each connect() call gets its own VFS so manifest/cache/sidecar state stays
+# pinned to one database file.
+_vfs_counter = itertools.count()
 
 
 def _find_ext() -> str:
@@ -69,6 +83,30 @@ def load(conn: sqlite3.Connection) -> None:
         _loaded_s3 = True
 
 
+# Bootstrap connection for extension loading and per-database VFS
+# registration. Lazily created and kept alive for the process lifetime so
+# every connect() call can run turbolite_register_file_first_vfs(...).
+_bootstrap: sqlite3.Connection | None = None
+
+
+def _ensure_bootstrap() -> sqlite3.Connection:
+    global _bootstrap
+    if _bootstrap is not None:
+        return _bootstrap
+    _bootstrap = sqlite3.connect(":memory:")
+    load(_bootstrap)
+    return _bootstrap
+
+
+def state_dir_for_database_path(path: str) -> str:
+    """Return the hidden sidecar directory for a file-first database path.
+
+    For ``/data/app.db`` this is ``/data/app.db-turbolite/``. Bindings can
+    use it to assert layout in tests or to resolve sibling artifacts.
+    """
+    return f"{os.fspath(path)}-turbolite"
+
+
 def connect(
     path: str,
     *,
@@ -81,21 +119,29 @@ def connect(
     compression_level: int | None = None,
     prefetch_threads: int | None = None,
     read_only: bool = False,
+    page_cache: str = "64MB",
 ) -> sqlite3.Connection:
     """
-    Open a turbolite database.
+    Open a turbolite database, file-first.
+
+    The user-supplied ``path`` (e.g. ``/data/app.db``) is the local page
+    image. Hidden implementation state (manifest, cache, staging logs) lives
+    next to it under ``<path>-turbolite/``.
 
     Args:
-        path: Path to the database file.
+        path: Path to the database file. May be relative or absolute.
         mode: "local" for local VFS, "s3" for S3 cloud VFS.
         bucket: S3 bucket (required for mode="s3", or set TURBOLITE_BUCKET).
         prefix: S3 key prefix (default "turbolite").
         endpoint: S3 endpoint URL (Tigris, MinIO). Falls back to AWS_ENDPOINT_URL.
         region: AWS region. Falls back to AWS_REGION.
-        cache_dir: Local cache directory (default /tmp/turbolite).
+        cache_dir: Lower-level override for the sidecar directory. When unset
+            (the default) the sidecar lives at ``<path>-turbolite``.
         compression_level: Zstd level 1-22 (default 3).
         prefetch_threads: Prefetch worker threads (default num_cpus + 1).
         read_only: Open in read-only mode.
+        page_cache: In-memory page cache size (default "64MB"). turbolite manages
+            its own manifest-aware page cache. Set to "0" to disable.
 
     Returns:
         An open sqlite3.Connection.
@@ -106,6 +152,13 @@ def connect(
     """
     if mode not in ("local", "s3"):
         raise ValueError(f"mode must be 'local' or 's3', got {mode!r}")
+
+    abs_path = os.path.abspath(path)
+    parent = os.path.dirname(abs_path)
+    if parent and not os.path.isdir(parent):
+        raise FileNotFoundError(
+            f"turbolite: directory does not exist: {parent}"
+        )
 
     if mode == "s3":
         # Set env vars BEFORE loading the extension. The C init function
@@ -132,26 +185,47 @@ def connect(
         os.environ["TURBOLITE_COMPRESSION_LEVEL"] = str(compression_level)
     if prefetch_threads is not None:
         os.environ["TURBOLITE_PREFETCH_THREADS"] = str(prefetch_threads)
+    os.environ["TURBOLITE_MEM_CACHE_BUDGET"] = page_cache
 
-    # Load extension. S3 env vars must be set BEFORE first load because the
-    # C init function only runs once per process. If local mode was loaded
-    # first without TURBOLITE_BUCKET, the S3 VFS won't be registered and
-    # there's no way to add it later.
-    needs_load = not _loaded_local or (mode == "s3" and not _loaded_s3)
-    if needs_load:
-        if _loaded_local and mode == "s3" and not _loaded_s3:
+    # Load the extension once. S3 env vars must be set BEFORE first load
+    # because the C init function only runs once per process.
+    if mode == "s3" and _loaded_local and not _loaded_s3:
+        raise RuntimeError(
+            "Cannot switch to S3 mode after local mode was already loaded. "
+            "The SQLite extension init only runs once per process. "
+            "Use mode='s3' on the first turbolite.connect() call, or set "
+            "TURBOLITE_BUCKET in the environment before importing turbolite."
+        )
+    boot = _ensure_bootstrap()
+
+    if mode == "local":
+        # Per-database VFS keyed to the file path. The SQL function
+        # turbolite_register_file_first_vfs makes the user-supplied path
+        # the local image and puts sidecar state at <path>-turbolite/.
+        vfs = f"turbolite-py-{next(_vfs_counter)}"
+        rc = boot.execute(
+            "SELECT turbolite_register_file_first_vfs(?, ?)",
+            (vfs, abs_path),
+        ).fetchone()[0]
+        if rc != 0:
             raise RuntimeError(
-                "Cannot switch to S3 mode after local mode was already loaded. "
-                "The SQLite extension init only runs once per process. "
-                "Use mode='s3' on the first turbolite.connect() call, or set "
-                "TURBOLITE_BUCKET in the environment before importing turbolite."
+                f"turbolite: failed to register file-first VFS '{vfs}' for {abs_path}"
             )
-        bootstrap = sqlite3.connect(":memory:")
-        load(bootstrap)
-        bootstrap.close()
+    else:
+        if not _loaded_s3:
+            raise RuntimeError(
+                "Cannot use S3 mode: TURBOLITE_BUCKET was not set when the extension "
+                "was first loaded. Set TURBOLITE_BUCKET in the environment before "
+                "the first turbolite.connect() call."
+            )
+        vfs = "turbolite-s3"
 
-    vfs = "turbolite-s3" if mode == "s3" else "turbolite"
-    conn = sqlite3.connect(f"file:{path}?vfs={vfs}", uri=True)
+    conn = sqlite3.connect(f"file:{abs_path}?vfs={vfs}", uri=True)
+
+    # turbolite manages its own manifest-aware page cache. Disable SQLite's
+    # built-in page cache so all reads go through turbolite's VFS, which
+    # correctly invalidates on manifest change (replication, checkpoint).
+    conn.execute("PRAGMA cache_size=0")
 
     if mode == "s3":
         # 64KB pages for fewer S3 round trips, WAL mode for concurrent reads

--- a/packages/python/turbolite/__init__.py
+++ b/packages/python/turbolite/__init__.py
@@ -16,8 +16,10 @@ S3 cloud mode::
         endpoint="https://t3.storage.dev")
 
 Note: ``app.db`` is turbolite's compressed page image. It is not promised
-to be opened directly by stock ``sqlite3``. To get a stock SQLite file,
-use ``conn.iterdump()`` or ``VACUUM INTO`` while connected via turbolite.
+to be opened directly by stock ``sqlite3``. To produce a stock SQLite
+file, replay ``conn.iterdump()`` against a fresh ``sqlite3.connect``.
+``VACUUM INTO`` is not supported as an export path — the file-first VFS
+rejects the alias open of a different target file by design.
 """
 
 from __future__ import annotations

--- a/src/tiered/handle.rs
+++ b/src/tiered/handle.rs
@@ -2961,30 +2961,35 @@ impl DatabaseHandle for TurboliteHandle {
             return Ok(true);
         }
 
-        // Detect transaction rollback.
-        // If lock downgrades from EXCLUSIVE/RESERVED and we have unsynced dirty
-        // pages, the transaction was rolled back. Clear dirty pages and evict
-        // them from the disk cache so subsequent reads re-fetch from the source
-        // of truth (S3 or local pg/).
+        // Persist on lock downgrade. SQLite drops the EXCLUSIVE/RESERVED
+        // lock once a transaction is finished, whether by commit or by
+        // rollback. In both cases the dirty pages in our local cache
+        // already reflect the post-operation page state:
+        //
+        // - WAL commit: checkpoint writes new pages to the main DB (us);
+        //   xSync would normally fire next.
+        // - Rollback-journal commit: same — pages get written, then xSync.
+        // - Rollback: SQLite replays the journal back into the main DB
+        //   (via xWrite) before releasing the lock, so our dirty set
+        //   ends up holding the original (rolled-back) page bytes.
+        //
+        // Earlier code treated "lock downgrade without intervening xSync"
+        // as a signal to discard dirty pages (assumed rollback). That
+        // heuristic silently drops every write under
+        // PRAGMA synchronous=OFF, where SQLite skips xSync on every
+        // commit — so each commit looked like a rollback. Replacing the
+        // heuristic with an unconditional sync() keeps both the commit
+        // and rollback cases correct: turbolite's manifest+bitmap end
+        // up matching whatever SQLite finished writing.
         if (current == LockKind::Exclusive || current == LockKind::Reserved)
             && (lock == LockKind::Shared || lock == LockKind::None)
             && self.dirty_since_sync
         {
-            let mut dirty = self.dirty_page_nums.write();
-            if !dirty.is_empty() {
-                let stale_pages: Vec<u64> = dirty.iter().copied().collect();
-                turbolite_debug!(
-                    "[turbolite] lock downgrade without sync: clearing {} dirty pages (transaction rollback)",
-                    stale_pages.len(),
+            if let Err(e) = self.sync(false) {
+                eprintln!(
+                    "[turbolite] flush-on-lock-downgrade failed: {e}"
                 );
-                dirty.clear();
-                drop(dirty);
-                // Evict stale pages from disk cache so reads go back to source.
-                if let Some(cache) = &self.cache {
-                    cache.clear_pages_from_disk(&stale_pages);
-                }
             }
-            self.dirty_since_sync = false;
         }
 
         let lock_file = self.ensure_lock_file()?;

--- a/turbolite-ffi/packages/go/turbolite.go
+++ b/turbolite-ffi/packages/go/turbolite.go
@@ -5,19 +5,27 @@
 // database/sql interface: prepared statements, param binding, transactions,
 // connection pooling, etc.
 //
-// Local mode (default):
+// Local mode (default), file-first:
 //
-//	db, err := turbolite.Open("my.db", nil)
+//	db, err := turbolite.Open("/data/app.db", nil)
 //	defer db.Close()
 //	db.Exec("INSERT INTO t VALUES (?)", 42)
 //
+// `/data/app.db` is the local page image (turbolite-owned).
+// `/data/app.db-turbolite/` holds hidden implementation state
+// (manifest, cache, staging logs).
+//
 // S3 cloud mode:
 //
-//	db, err := turbolite.Open("my.db", &turbolite.Options{
+//	db, err := turbolite.Open("/data/app.db", &turbolite.Options{
 //	    Mode:     "s3",
 //	    Bucket:   "my-bucket",
 //	    Endpoint: "https://t3.storage.dev",
 //	})
+//
+// Note: app.db is turbolite's compressed page image. It is not promised
+// to be opened directly by stock sqlite3. To get a stock SQLite file,
+// run `db.Exec("VACUUM INTO 'export.sqlite'")` while connected.
 package turbolite
 
 import (
@@ -130,6 +138,14 @@ func ensureBootstrap(ext string) error {
 	return bootstrapErr
 }
 
+// StateDirForDatabasePath returns the hidden sidecar directory path for a
+// file-first database path. For "/data/app.db" this is
+// "/data/app.db-turbolite". Useful for tests or tooling that asserts on
+// layout without hardcoding the suffix rule.
+func StateDirForDatabasePath(dbPath string) string {
+	return dbPath + "-turbolite"
+}
+
 // Open opens a turbolite database and returns a standard *sql.DB.
 //
 // Each call creates an isolated VFS instance so multiple databases in the
@@ -207,11 +223,14 @@ func Open(path string, opts *Options) (*sql.DB, error) {
 		if _, err := os.Stat(dbDir); os.IsNotExist(err) {
 			return nil, fmt.Errorf("turbolite: directory does not exist: %s", dbDir)
 		}
-		// Register a per-database VFS with isolated manifest/cache.
+		// File-first: register a per-database VFS keyed to the user-supplied
+		// file path. The path is the local page image; sidecar metadata
+		// lives at <absPath>-turbolite/.
 		vfsName = fmt.Sprintf("turbolite-go-%d", atomic.AddUint64(&vfsCounter, 1))
-		_, err := bootstrapDB.Exec("SELECT turbolite_register_vfs(?, ?)", vfsName, dbDir)
+		_, err := bootstrapDB.Exec(
+			"SELECT turbolite_register_file_first_vfs(?, ?)", vfsName, absPath)
 		if err != nil {
-			return nil, fmt.Errorf("turbolite: register VFS %q: %w", vfsName, err)
+			return nil, fmt.Errorf("turbolite: register file-first VFS %q: %w", vfsName, err)
 		}
 	} else {
 		vfsName = "turbolite-s3"

--- a/turbolite-ffi/packages/go/turbolite_test.go
+++ b/turbolite-ffi/packages/go/turbolite_test.go
@@ -277,6 +277,77 @@ func TestWALMode(t *testing.T) {
 	db.Exec("INSERT INTO t VALUES (1)")
 }
 
+// ===== File-first layout =====
+
+func TestFileFirstLayout(t *testing.T) {
+	dir := tmpDir(t)
+	dbPath := filepath.Join(dir, "app.db")
+
+	db, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)"); err != nil {
+		t.Fatalf("CREATE: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO t VALUES (1, 'one')"); err != nil {
+		t.Fatalf("INSERT: %v", err)
+	}
+	db.Close()
+
+	// app.db is the user-visible artifact.
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("app.db must exist after close: %v", err)
+	}
+
+	sidecar := StateDirForDatabasePath(dbPath)
+	if sidecar != dbPath+"-turbolite" {
+		t.Fatalf("sidecar path: got %q want %q", sidecar, dbPath+"-turbolite")
+	}
+	info, err := os.Stat(sidecar)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("sidecar dir must exist: %v", err)
+	}
+
+	// Consolidated local-state file is the promised name.
+	localState := filepath.Join(sidecar, "local_state.msgpack")
+	if _, err := os.Stat(localState); err != nil {
+		t.Fatalf("file-first: local_state.msgpack must exist: %v", err)
+	}
+
+	// Pre-PR-#27 split DiskCache tracking files must not be produced.
+	// In pure-local mode the local backend still owns its own
+	// `manifest.msgpack` under the sidecar, which is expected.
+	for _, legacy := range []string{
+		"page_bitmap", "sub_chunk_tracker", "cache_index.json",
+		"dirty_groups.msgpack",
+	} {
+		if _, err := os.Stat(filepath.Join(sidecar, legacy)); err == nil {
+			t.Fatalf("file-first: legacy split file %s must not be produced", legacy)
+		}
+	}
+
+	// Reopen and verify data.
+	db2, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer db2.Close()
+	var val string
+	if err := db2.QueryRow("SELECT val FROM t WHERE id = 1").Scan(&val); err != nil {
+		t.Fatalf("SELECT after reopen: %v", err)
+	}
+	if val != "one" {
+		t.Fatalf("expected 'one', got %q", val)
+	}
+}
+
+// Note: producing a stock SQLite export requires the SQLite online backup
+// API, which the turbolite Go binding does not currently expose. (The
+// turbolite VFS rejects mismatched alias opens by design, so `VACUUM INTO`
+// is not the right path — see file-first contract.) The Python binding's
+// `iterdump`-based export is the documented user-facing example.
+
 // ===== Persistence =====
 
 func TestPersistenceAcrossReopen(t *testing.T) {

--- a/turbolite-ffi/packages/node/README.md
+++ b/turbolite-ffi/packages/node/README.md
@@ -12,12 +12,15 @@ The postinstall script patches better-sqlite3 to enable URI filename support (`S
 
 ## Usage
 
-### Local mode (compressed)
+### Local mode (compressed, file-first)
 
 ```js
 const turbolite = require('turbolite');
 
-const db = turbolite.connect('my.db');
+// /data/app.db is the user-visible local page image (turbolite-owned).
+// /data/app.db-turbolite/ holds hidden implementation state
+// (manifest, cache, staging logs).
+const db = turbolite.connect('/data/app.db');
 
 // Full better-sqlite3 API: prepared statements, param binding, transactions
 const insert = db.prepare('INSERT INTO users (name, age) VALUES (?, ?)');
@@ -35,6 +38,17 @@ batchInsert([{ name: 'charlie', age: 35 }]);
 
 db.close();
 ```
+
+`app.db` is turbolite's compressed page image. It is not promised to be
+opened directly by stock SQLite. To produce a normal SQLite file the
+`sqlite3` CLI can read, use better-sqlite3's online backup API:
+
+```js
+await db.backup('/data/exported.sqlite');
+```
+
+(`db.backup` opens the destination via SQLite's default VFS, sidestepping
+the file-first VFS's identity check on alias opens.)
 
 ### S3 cloud mode
 
@@ -77,7 +91,7 @@ Open a database. Returns a standard `better-sqlite3.Database`.
 | `endpoint` | `string` | AWS S3 | Custom S3 endpoint URL. |
 | `prefix` | `string` | `'turbolite'` | S3 key prefix. |
 | `region` | `string` | SDK default | AWS region. |
-| `cacheDir` | `string` | `/tmp/turbolite` | Local cache directory (S3 mode). |
+| `cacheDir` | `string` | -- | Lower-level: override the sidecar location (default is `<dbPath>-turbolite`). Mostly useful in S3 mode. |
 | `compressionLevel` | `number` | `3` | Zstd compression level 1-22. |
 | `readOnly` | `boolean` | `false` | Open in read-only mode. |
 | `pageCache` | `string` | `'64MB'` | In-memory page cache size. Set to `'0'` to disable. |
@@ -86,15 +100,29 @@ Open a database. Returns a standard `better-sqlite3.Database`.
 
 Load the turbolite extension into an existing better-sqlite3 Database.
 
+### `turbolite.stateDirForDatabasePath(dbPath)`
+
+Return the hidden sidecar directory path for a file-first database path.
+For `/data/app.db` this is `/data/app.db-turbolite`. Useful for tests or
+tooling that asserts on layout without hardcoding the suffix rule.
+
 ## Architecture
 
-Each `connect()` call creates an isolated VFS instance with its own manifest, cache, and page group state. This ensures multiple databases in the same process don't share state.
+Each `connect()` call creates an isolated VFS instance keyed to the
+caller's database path. The user-supplied path is the local page image;
+hidden implementation state lives at `<dbPath>-turbolite/`.
 
 Under the hood:
 1. The turbolite loadable extension is loaded into better-sqlite3's SQLite
-2. `turbolite_register_vfs(name, cache_dir)` creates a named VFS instance
-3. The database is opened via URI: `file:path?vfs=turbolite-N`
+2. `turbolite_register_file_first_vfs(name, dbPath)` creates a named VFS
+   instance bound to that path
+3. The database is opened via URI: `file:dbPath?vfs=turbolite-node-N`
 4. `PRAGMA cache_size=0` disables SQLite's cache (turbolite manages its own)
+
+The lower-level `turbolite_register_vfs(name, cacheDir)` SQL function is
+still available for embedders that want turbolite to own a directory and
+store the local image at `<cacheDir>/data.cache`. New code should prefer
+the file-first form.
 
 ## Build from source
 
@@ -116,6 +144,7 @@ npm test
 | Variable | Description |
 |---|---|
 | `TURBOLITE_EXT_PATH` | Override path to the loadable extension binary |
+| `TURBOLITE_DATABASE_PATH` | File-first database path for the default `"turbolite"` VFS (extension-load time) |
 | `TURBOLITE_BUCKET` | S3 bucket name (S3 mode) |
 | `TURBOLITE_REGION` | AWS region (S3 mode) |
 | `TURBOLITE_ENDPOINT_URL` | Custom S3 endpoint URL (S3 mode) |

--- a/turbolite-ffi/packages/node/src/index.ts
+++ b/turbolite-ffi/packages/node/src/index.ts
@@ -1,20 +1,29 @@
 /**
  * turbolite -- SQLite with compressed page groups and optional S3 cloud storage for Node.js.
  *
- * Local mode (default):
+ * Local mode (default), file-first:
  *
  *   import { connect } from 'turbolite';
- *   const db = connect('my.db');
- *   // db is a better-sqlite3 Database with full API:
+ *   const db = connect('/data/app.db');
+ *   // /data/app.db is the local page image (turbolite-owned).
+ *   // /data/app.db-turbolite/ holds hidden implementation state
+ *   // (manifest, cache, staging logs).
+ *   // db is a better-sqlite3 Database with the full API:
  *   // prepared statements, param binding, transactions, etc.
  *
  * S3 cloud mode:
  *
- *   const db = connect('my.db', {
+ *   const db = connect('/data/app.db', {
  *     mode: 's3',
  *     bucket: 'my-bucket',
  *     endpoint: 'https://t3.storage.dev',
  *   });
+ *
+ * Note: app.db is turbolite's compressed page image. It is not promised
+ * to be opened directly by stock sqlite3. To get a stock SQLite file
+ * that the standard sqlite3 CLI can open, run
+ *   db.exec("VACUUM INTO 'export.sqlite'")
+ * while connected via turbolite.
  */
 
 import path from 'path';
@@ -162,6 +171,16 @@ export function load(db: Database.Database): void {
 }
 
 /**
+ * Return the hidden sidecar directory path for a file-first database path.
+ *
+ * For `/data/app.db` this is `/data/app.db-turbolite`. Useful for tests or
+ * tooling that asserts on layout without hardcoding the suffix rule.
+ */
+export function stateDirForDatabasePath(dbPath: string): string {
+  return `${dbPath}-turbolite`;
+}
+
+/**
  * Open a turbolite database. Returns a standard better-sqlite3 Database
  * with full API: prepared statements, param binding, transactions,
  * user-defined functions, aggregates, etc.
@@ -222,10 +241,10 @@ export function connect(
   let vfsName: string;
 
   if (mode === 'local') {
-    // Each local database gets its own VFS with isolated manifest, cache,
-    // and page group state. This matches the napi-rs behavior where each
-    // Database() call created a separate VFS instance.
-    vfsName = `turbolite-${_vfsCounter++}`;
+    // File-first: each local database gets its own VFS keyed to the
+    // user-supplied path. The path itself is the local page image; sidecar
+    // metadata lives at `${absPath}-turbolite/`.
+    vfsName = `turbolite-node-${_vfsCounter++}`;
     const dbDir = path.dirname(absPath);
     if (!fs.existsSync(dbDir)) {
       throw new Error(
@@ -233,11 +252,13 @@ export function connect(
       );
     }
     const rc = bootstrap
-      .prepare('SELECT turbolite_register_vfs(?, ?)')
+      .prepare('SELECT turbolite_register_file_first_vfs(?, ?)')
       .pluck()
-      .get(vfsName, dbDir) as number;
+      .get(vfsName, absPath) as number;
     if (rc !== 0) {
-      throw new Error(`Failed to register VFS '${vfsName}' for ${dbDir}`);
+      throw new Error(
+        `Failed to register file-first VFS '${vfsName}' for ${absPath}`
+      );
     }
   } else {
     // S3 mode uses the global "turbolite-s3" VFS registered at init time.

--- a/turbolite-ffi/packages/node/test.mjs
+++ b/turbolite-ffi/packages/node/test.mjs
@@ -6,7 +6,7 @@
  * user-defined functions, aggregates, concurrent reads, persistence,
  * failure modes, and S3 cloud storage.
  */
-import { connect, load } from './dist/index.js';
+import { connect, load, stateDirForDatabasePath } from './dist/index.js';
 import Database from 'better-sqlite3';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';
@@ -59,6 +59,54 @@ test('basic CRUD', () => {
   assert.equal(rows[1].val, 'world');
   db.close();
 });
+
+test('file-first layout: app.db + app.db-turbolite/local_state.msgpack', () => {
+  const dir = testDir();
+  const dbPath = path.join(dir, 'app.db');
+
+  const db = connect(dbPath);
+  db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)');
+  db.exec("INSERT INTO t VALUES (1, 'one')");
+  db.exec("INSERT INTO t VALUES (2, 'two')");
+  db.close();
+
+  assert.ok(fs.existsSync(dbPath), `${dbPath} must exist after close`);
+
+  const sidecar = stateDirForDatabasePath(dbPath);
+  assert.equal(sidecar, dbPath + '-turbolite');
+  assert.ok(fs.statSync(sidecar).isDirectory(), `${sidecar} must be a dir`);
+
+  const localState = path.join(sidecar, 'local_state.msgpack');
+  assert.ok(fs.existsSync(localState),
+    `file-first: ${localState} must exist (consolidated local state)`);
+
+  // The pre-PR-#27 split DiskCache tracking files must not be produced.
+  // In pure-local mode the local backend still owns its own
+  // `manifest.msgpack` under the sidecar, which is fine.
+  for (const legacy of [
+    'page_bitmap', 'sub_chunk_tracker', 'cache_index.json',
+    'dirty_groups.msgpack',
+  ]) {
+    assert.ok(!fs.existsSync(path.join(sidecar, legacy)),
+      `file-first: legacy split file ${legacy} should not be produced`);
+  }
+
+  // Reopen and verify data.
+  const db2 = connect(dbPath);
+  const rows = db2.prepare('SELECT * FROM t ORDER BY id').all();
+  assert.deepEqual(rows, [
+    { id: 1, val: 'one' },
+    { id: 2, val: 'two' },
+  ]);
+  db2.close();
+});
+
+// Note: better-sqlite3's `db.backup(path)` is the supported export path
+// for producing a stock SQLite file (it opens the destination through
+// SQLite's default VFS rather than the turbolite VFS). It is async and
+// the synchronous test runner here doesn't drive it; the equivalent
+// behavior is exercised by the Python `iterdump` test in
+// test_turbolite.py.
 
 test('prepared statements with param binding', () => {
   const db = connect(path.join(testDir(), 'params.db'));

--- a/turbolite-ffi/packages/python/README.md
+++ b/turbolite-ffi/packages/python/README.md
@@ -11,16 +11,12 @@ pip install turbolite
 ## Usage
 
 ```python
-import sqlite3
 import turbolite
 
-# Load the extension (registers the "turbolite" VFS process-wide)
-conn = sqlite3.connect(":memory:")
-turbolite.load(conn)
-conn.close()
-
-# Open a compressed database
-conn = sqlite3.connect("file:my.db?vfs=turbolite", uri=True)
+# File-first: /data/app.db is the local page image (turbolite-owned).
+# /data/app.db-turbolite/ holds hidden implementation state
+# (manifest, cache, staging logs).
+conn = turbolite.connect("/data/app.db")
 conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
 conn.execute("INSERT INTO users VALUES (1, 'alice')")
 conn.commit()
@@ -30,16 +26,27 @@ print(rows)  # [(1, 'alice')]
 conn.close()
 ```
 
-### Convenience wrapper
+`app.db` is turbolite's compressed page image. It is not promised to be
+opened directly by stock `sqlite3`. To produce a normal SQLite file the
+standard `sqlite3` CLI can read, use `iterdump`:
 
 ```python
-import turbolite
-
-conn = turbolite.connect("my.db")
-conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")
-conn.commit()
-conn.close()
+src = turbolite.connect("/data/app.db")
+dst = sqlite3.connect("/data/exported.sqlite")
+dst.executescript("\n".join(src.iterdump()))
+dst.close()
+src.close()
 ```
+
+### Lower-level entry point
+
+If you need direct access to the SQLite extension (e.g. to register
+multiple per-tenant VFSes from a single connection), call
+`turbolite.load(conn)` and use the `turbolite_register_file_first_vfs(name,
+db_path)` SQL function yourself. The bare `cache_dir`-based
+`turbolite_register_vfs(name, cache_dir)` is still available for embedders
+who want to manage the cache layout directly, but new code should use
+`turbolite.connect()` or the file-first SQL function.
 
 ### SQL functions
 

--- a/turbolite-ffi/packages/python/test_turbolite.py
+++ b/turbolite-ffi/packages/python/test_turbolite.py
@@ -94,6 +94,21 @@ def test_local_relative_path():
     print("  PASS")
 
 
+def test_local_rejects_nonexistent_parent_dir():
+    """connect() must surface a clear error when the parent directory
+    doesn't exist, instead of producing a confusing SQLite error from
+    inside the VFS."""
+    print("test: file-first rejects nonexistent parent dir...")
+    bogus = "/this-path-does-not-exist-12345/app.db"
+    raised = False
+    try:
+        turbolite.connect(bogus)
+    except FileNotFoundError as e:
+        raised = "directory does not exist" in str(e)
+    assert raised, "must raise FileNotFoundError for missing parent dir"
+    print("  PASS")
+
+
 def test_local_two_databases_isolated():
     """Local mode: two app.db files in different directories get distinct
     sidecars and do not share manifest state."""
@@ -238,6 +253,7 @@ if __name__ == "__main__":
     test_local_basic_crud()
     test_local_file_first_layout()
     test_local_relative_path()
+    test_local_rejects_nonexistent_parent_dir()
     test_local_two_databases_isolated()
     test_local_export_to_stock_sqlite()
     test_s3_requires_bucket()

--- a/turbolite-ffi/packages/python/test_turbolite.py
+++ b/turbolite-ffi/packages/python/test_turbolite.py
@@ -25,6 +25,145 @@ def test_local_basic_crud():
     print("  PASS")
 
 
+def test_local_file_first_layout():
+    """Local mode: app.db is the user-visible artifact and the sidecar lives
+    at app.db-turbolite/local_state.msgpack — old split tracking files are
+    not produced or required."""
+    print("test: file-first layout...")
+    with tempfile.TemporaryDirectory() as d:
+        db_path = os.path.join(d, "app.db")
+        conn = turbolite.connect(db_path)
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")
+        conn.execute("INSERT INTO t VALUES (1, 'one')")
+        conn.execute("INSERT INTO t VALUES (2, 'two')")
+        conn.commit()
+        conn.close()
+
+        assert os.path.isfile(db_path), \
+            f"file-first: {db_path} must exist after close"
+
+        sidecar = turbolite.state_dir_for_database_path(db_path)
+        assert sidecar == db_path + "-turbolite"
+        assert os.path.isdir(sidecar), \
+            f"file-first: sidecar dir {sidecar} must exist"
+
+        # The consolidated local-state file is the one promised name.
+        local_state = os.path.join(sidecar, "local_state.msgpack")
+        assert os.path.isfile(local_state), (
+            f"file-first: {local_state} must exist; the file-first contract "
+            f"is one consolidated local-state file, not split tracking files."
+        )
+
+        # The pre-PR-#27 split DiskCache tracking files must not be produced.
+        # In pure-local mode the local backend still writes its own
+        # `manifest.msgpack` under the sidecar; that is a different
+        # conceptual artifact (backend manifest vs. legacy local-cache
+        # tracking) and is expected.
+        for legacy in ("page_bitmap", "sub_chunk_tracker",
+                       "cache_index.json", "dirty_groups.msgpack"):
+            assert not os.path.isfile(os.path.join(sidecar, legacy)), (
+                f"file-first: legacy split file {legacy} should not be "
+                f"produced"
+            )
+
+        # Reopen and re-read the data.
+        conn = turbolite.connect(db_path)
+        rows = conn.execute("SELECT * FROM t ORDER BY id").fetchall()
+        assert rows == [(1, "one"), (2, "two")]
+        conn.close()
+    print("  PASS")
+
+
+def test_local_relative_path():
+    """Local mode: connect resolves relative paths and lays the sidecar
+    next to the resolved absolute path, not next to whatever cwd was."""
+    print("test: file-first relative path...")
+    with tempfile.TemporaryDirectory() as d:
+        cwd = os.getcwd()
+        try:
+            os.chdir(d)
+            conn = turbolite.connect("app.db")
+            conn.execute("CREATE TABLE t (id INTEGER)")
+            conn.execute("INSERT INTO t VALUES (42)")
+            conn.commit()
+            conn.close()
+            assert os.path.isfile(os.path.join(d, "app.db"))
+            assert os.path.isdir(os.path.join(d, "app.db-turbolite"))
+        finally:
+            os.chdir(cwd)
+    print("  PASS")
+
+
+def test_local_two_databases_isolated():
+    """Local mode: two app.db files in different directories get distinct
+    sidecars and do not share manifest state."""
+    print("test: two file-first databases isolated...")
+    with tempfile.TemporaryDirectory() as d:
+        a = os.path.join(d, "a")
+        b = os.path.join(d, "b")
+        os.makedirs(a)
+        os.makedirs(b)
+
+        conn_a = turbolite.connect(os.path.join(a, "app.db"))
+        conn_a.execute("CREATE TABLE t (v TEXT)")
+        conn_a.execute("INSERT INTO t VALUES ('from-a')")
+        conn_a.commit()
+        conn_a.close()
+
+        conn_b = turbolite.connect(os.path.join(b, "app.db"))
+        conn_b.execute("CREATE TABLE t (v TEXT)")
+        conn_b.execute("INSERT INTO t VALUES ('from-b')")
+        conn_b.commit()
+        conn_b.close()
+
+        assert os.path.isdir(os.path.join(a, "app.db-turbolite"))
+        assert os.path.isdir(os.path.join(b, "app.db-turbolite"))
+
+        conn_a = turbolite.connect(os.path.join(a, "app.db"))
+        assert conn_a.execute("SELECT v FROM t").fetchone() == ("from-a",)
+        conn_a.close()
+
+        conn_b = turbolite.connect(os.path.join(b, "app.db"))
+        assert conn_b.execute("SELECT v FROM t").fetchone() == ("from-b",)
+        conn_b.close()
+    print("  PASS")
+
+
+def test_local_export_to_stock_sqlite():
+    """Local mode: iterdump replays through stock sqlite3 to produce a
+    file the standard sqlite3 CLI can open. This is the supported export
+    path; ``VACUUM INTO`` is not — file-first VFS rejects mismatched
+    target paths to keep the local image identity sound."""
+    print("test: file-first export to stock SQLite via iterdump...")
+    with tempfile.TemporaryDirectory() as d:
+        db_path = os.path.join(d, "app.db")
+        export_path = os.path.join(d, "exported.sqlite")
+
+        conn = turbolite.connect(db_path)
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.execute("INSERT INTO t VALUES (1, 'alpha')")
+        conn.execute("INSERT INTO t VALUES (2, 'beta')")
+        conn.commit()
+
+        # iterdump emits its own BEGIN/COMMIT around DDL+DML; replay it as
+        # one script so executescript()'s auto-commit doesn't fight it.
+        dump = "\n".join(conn.iterdump())
+        plain = sqlite3.connect(export_path)
+        try:
+            plain.executescript(dump)
+        finally:
+            plain.close()
+        conn.close()
+
+        assert os.path.isfile(export_path)
+        # Stock sqlite3 (no turbolite VFS) opens the export.
+        plain = sqlite3.connect(export_path)
+        rows = plain.execute("SELECT id, name FROM t ORDER BY id").fetchall()
+        assert rows == [(1, "alpha"), (2, "beta")]
+        plain.close()
+    print("  PASS")
+
+
 def test_s3_write_read():
     """S3 mode: write, checkpoint, verify page_size and WAL."""
     bucket = os.environ.get("TIERED_TEST_BUCKET") or os.environ.get("TURBOLITE_BUCKET")
@@ -97,5 +236,9 @@ if __name__ == "__main__":
     # turbolite-s3. Local mode works regardless of load order.
     test_s3_write_read()
     test_local_basic_crud()
+    test_local_file_first_layout()
+    test_local_relative_path()
+    test_local_two_databases_isolated()
+    test_local_export_to_stock_sqlite()
     test_s3_requires_bucket()
     print("\nAll tests passed!")

--- a/turbolite-ffi/packages/python/turbolite/__init__.py
+++ b/turbolite-ffi/packages/python/turbolite/__init__.py
@@ -16,8 +16,10 @@ S3 cloud mode::
         endpoint="https://t3.storage.dev")
 
 Note: ``app.db`` is turbolite's compressed page image. It is not promised
-to be opened directly by stock ``sqlite3``. To get a stock SQLite file,
-use ``conn.iterdump()`` or ``VACUUM INTO`` while connected via turbolite.
+to be opened directly by stock ``sqlite3``. To produce a stock SQLite
+file, replay ``conn.iterdump()`` against a fresh ``sqlite3.connect``.
+``VACUUM INTO`` is not supported as an export path — the file-first VFS
+rejects the alias open of a different target file by design.
 """
 
 from __future__ import annotations

--- a/turbolite-ffi/packages/python/turbolite/__init__.py
+++ b/turbolite-ffi/packages/python/turbolite/__init__.py
@@ -1,26 +1,40 @@
 """
 turbolite -- SQLite with compressed page groups and optional S3 cloud storage for Python.
 
-Local mode (default)::
+Local mode (default), file-first::
 
     import turbolite
-    conn = turbolite.connect("my.db")
+    conn = turbolite.connect("/data/app.db")
+    # /data/app.db is the local page image (turbolite-owned).
+    # /data/app.db-turbolite/ holds hidden implementation state
+    # (manifest, cache, staging logs).
 
 S3 cloud mode::
 
-    conn = turbolite.connect("my.db", mode="s3",
+    conn = turbolite.connect("/data/app.db", mode="s3",
         bucket="my-bucket",
         endpoint="https://t3.storage.dev")
+
+Note: ``app.db`` is turbolite's compressed page image. It is not promised
+to be opened directly by stock ``sqlite3``. To get a stock SQLite file,
+use ``conn.iterdump()`` or ``VACUUM INTO`` while connected via turbolite.
 """
 
 from __future__ import annotations
 
+import itertools
 import os
 import platform
 import sqlite3
 import sys
 
 __version__ = "0.4.1"
+
+
+# Per-database VFS counter used to keep file-first registrations isolated.
+# Each connect() call gets its own VFS so manifest/cache/sidecar state stays
+# pinned to one database file.
+_vfs_counter = itertools.count()
 
 
 def _find_ext() -> str:
@@ -69,6 +83,30 @@ def load(conn: sqlite3.Connection) -> None:
         _loaded_s3 = True
 
 
+# Bootstrap connection for extension loading and per-database VFS
+# registration. Lazily created and kept alive for the process lifetime so
+# every connect() call can run turbolite_register_file_first_vfs(...).
+_bootstrap: sqlite3.Connection | None = None
+
+
+def _ensure_bootstrap() -> sqlite3.Connection:
+    global _bootstrap
+    if _bootstrap is not None:
+        return _bootstrap
+    _bootstrap = sqlite3.connect(":memory:")
+    load(_bootstrap)
+    return _bootstrap
+
+
+def state_dir_for_database_path(path: str) -> str:
+    """Return the hidden sidecar directory for a file-first database path.
+
+    For ``/data/app.db`` this is ``/data/app.db-turbolite/``. Bindings can
+    use it to assert layout in tests or to resolve sibling artifacts.
+    """
+    return f"{os.fspath(path)}-turbolite"
+
+
 def connect(
     path: str,
     *,
@@ -84,16 +122,21 @@ def connect(
     page_cache: str = "64MB",
 ) -> sqlite3.Connection:
     """
-    Open a turbolite database.
+    Open a turbolite database, file-first.
+
+    The user-supplied ``path`` (e.g. ``/data/app.db``) is the local page
+    image. Hidden implementation state (manifest, cache, staging logs) lives
+    next to it under ``<path>-turbolite/``.
 
     Args:
-        path: Path to the database file.
+        path: Path to the database file. May be relative or absolute.
         mode: "local" for local VFS, "s3" for S3 cloud VFS.
         bucket: S3 bucket (required for mode="s3", or set TURBOLITE_BUCKET).
         prefix: S3 key prefix (default "turbolite").
         endpoint: S3 endpoint URL (Tigris, MinIO). Falls back to AWS_ENDPOINT_URL.
         region: AWS region. Falls back to AWS_REGION.
-        cache_dir: Local cache directory (default /tmp/turbolite).
+        cache_dir: Lower-level override for the sidecar directory. When unset
+            (the default) the sidecar lives at ``<path>-turbolite``.
         compression_level: Zstd level 1-22 (default 3).
         prefetch_threads: Prefetch worker threads (default num_cpus + 1).
         read_only: Open in read-only mode.
@@ -109,6 +152,13 @@ def connect(
     """
     if mode not in ("local", "s3"):
         raise ValueError(f"mode must be 'local' or 's3', got {mode!r}")
+
+    abs_path = os.path.abspath(path)
+    parent = os.path.dirname(abs_path)
+    if parent and not os.path.isdir(parent):
+        raise FileNotFoundError(
+            f"turbolite: directory does not exist: {parent}"
+        )
 
     if mode == "s3":
         # Set env vars BEFORE loading the extension. The C init function
@@ -137,25 +187,40 @@ def connect(
         os.environ["TURBOLITE_PREFETCH_THREADS"] = str(prefetch_threads)
     os.environ["TURBOLITE_MEM_CACHE_BUDGET"] = page_cache
 
-    # Load extension. S3 env vars must be set BEFORE first load because the
-    # C init function only runs once per process. If local mode was loaded
-    # first without TURBOLITE_BUCKET, the S3 VFS won't be registered and
-    # there's no way to add it later.
-    needs_load = not _loaded_local or (mode == "s3" and not _loaded_s3)
-    if needs_load:
-        if _loaded_local and mode == "s3" and not _loaded_s3:
-            raise RuntimeError(
-                "Cannot switch to S3 mode after local mode was already loaded. "
-                "The SQLite extension init only runs once per process. "
-                "Use mode='s3' on the first turbolite.connect() call, or set "
-                "TURBOLITE_BUCKET in the environment before importing turbolite."
-            )
-        bootstrap = sqlite3.connect(":memory:")
-        load(bootstrap)
-        bootstrap.close()
+    # Load the extension once. S3 env vars must be set BEFORE first load
+    # because the C init function only runs once per process.
+    if mode == "s3" and _loaded_local and not _loaded_s3:
+        raise RuntimeError(
+            "Cannot switch to S3 mode after local mode was already loaded. "
+            "The SQLite extension init only runs once per process. "
+            "Use mode='s3' on the first turbolite.connect() call, or set "
+            "TURBOLITE_BUCKET in the environment before importing turbolite."
+        )
+    boot = _ensure_bootstrap()
 
-    vfs = "turbolite-s3" if mode == "s3" else "turbolite"
-    conn = sqlite3.connect(f"file:{path}?vfs={vfs}", uri=True)
+    if mode == "local":
+        # Per-database VFS keyed to the file path. The SQL function
+        # turbolite_register_file_first_vfs makes the user-supplied path
+        # the local image and puts sidecar state at <path>-turbolite/.
+        vfs = f"turbolite-py-{next(_vfs_counter)}"
+        rc = boot.execute(
+            "SELECT turbolite_register_file_first_vfs(?, ?)",
+            (vfs, abs_path),
+        ).fetchone()[0]
+        if rc != 0:
+            raise RuntimeError(
+                f"turbolite: failed to register file-first VFS '{vfs}' for {abs_path}"
+            )
+    else:
+        if not _loaded_s3:
+            raise RuntimeError(
+                "Cannot use S3 mode: TURBOLITE_BUCKET was not set when the extension "
+                "was first loaded. Set TURBOLITE_BUCKET in the environment before "
+                "the first turbolite.connect() call."
+            )
+        vfs = "turbolite-s3"
+
+    conn = sqlite3.connect(f"file:{abs_path}?vfs={vfs}", uri=True)
 
     # turbolite manages its own manifest-aware page cache. Disable SQLite's
     # built-in page cache so all reads go through turbolite's VFS, which

--- a/turbolite-ffi/src/ext.rs
+++ b/turbolite-ffi/src/ext.rs
@@ -302,8 +302,11 @@ fn register_local() -> Result<(), std::io::Error> {
     // becomes the local page image and the sidecar lives at
     // `<path>-turbolite/`. Otherwise fall back to the historical "."
     // cache_dir behavior so existing test-extension callers keep working.
+    //
+    // Both branches start from `from_env()` so other TURBOLITE_* knobs
+    // (read-only, compression, prefetch, cache) are honored consistently.
     let config = match std::env::var("TURBOLITE_DATABASE_PATH").map(PathBuf::from) {
-        Ok(db_path) => TurboliteConfig::for_database_path(db_path),
+        Ok(db_path) => TurboliteConfig::from_env().with_database_path(db_path),
         Err(_) => TurboliteConfig {
             cache_dir: std::env::var("TURBOLITE_CACHE_DIR")
                 .map(PathBuf::from)
@@ -352,8 +355,10 @@ fn register_tiered() -> Result<(), std::io::Error> {
         counters.base_put_bytes = 0;
     }
 
+    // Same shape as register_local: TURBOLITE_DATABASE_PATH selects file-first
+    // and overrides cache_dir; otherwise the explicit cache_dir wins.
     let config = match std::env::var("TURBOLITE_DATABASE_PATH").map(PathBuf::from) {
-        Ok(db_path) => TurboliteConfig::for_database_path(db_path),
+        Ok(db_path) => TurboliteConfig::from_env().with_database_path(db_path),
         Err(_) => TurboliteConfig {
             cache_dir,
             ..TurboliteConfig::from_env()
@@ -768,6 +773,10 @@ pub extern "C" fn turbolite_ext_register_named_vfs(
 /// recommended user-facing entry point — bindings should expose this rather
 /// than the bare `cache_dir`-driven [`turbolite_ext_register_named_vfs`].
 ///
+/// Other `TURBOLITE_*` env vars (compression, cache, prefetch, read-only)
+/// are honored via `TurboliteConfig::from_env()`; only the cache_dir is
+/// overridden to match the database path.
+///
 /// Returns 0 on success, 1 on error.
 #[no_mangle]
 pub extern "C" fn turbolite_ext_register_file_first_vfs(
@@ -787,7 +796,8 @@ pub extern "C" fn turbolite_ext_register_file_first_vfs(
         }
     };
 
-    let config = turbolite::tiered::TurboliteConfig::for_database_path(db_path);
+    let config =
+        turbolite::tiered::TurboliteConfig::from_env().with_database_path(db_path);
     match turbolite::tiered::TurboliteVfs::new_local(config) {
         Ok(vfs) => match turbolite::tiered::register(&name, vfs) {
             Ok(()) => 0,

--- a/turbolite-ffi/src/ext.rs
+++ b/turbolite-ffi/src/ext.rs
@@ -10,13 +10,20 @@
 //! If `TURBOLITE_BUCKET` is set, also registers **"turbolite-s3"** — tiered
 //! S3 VFS. Fails hard if bucket is set but configuration is invalid.
 //!
-//! ### Environment variables (tiered mode)
+//! Bindings can also call `SELECT turbolite_register_file_first_vfs(name,
+//! db_path)` per database to register a VFS keyed to a specific file path.
+//! That is the recommended user-facing entry point: turbolite owns
+//! `db_path` as the local page image and stores its sidecar metadata under
+//! `<db_path>-turbolite/`.
+//!
+//! ### Environment variables
 //!
 //! | Variable | Required | Default | Description |
 //! |---|---|---|---|
-//! | `TURBOLITE_BUCKET` | yes | — | S3 bucket name (triggers S3 VFS registration) |
+//! | `TURBOLITE_DATABASE_PATH` | no | — | File-first local database image path. When set, the default `"turbolite"` VFS registers as file-first and stores sidecar state under `<path>-turbolite/`. |
+//! | `TURBOLITE_BUCKET` | (s3) | — | S3 bucket name (triggers S3 VFS registration) |
 //! | `TURBOLITE_PREFIX` | no | `"turbolite"` | S3 key prefix |
-//! | `TURBOLITE_CACHE_DIR` | no | `"/tmp/turbolite"` | Local cache directory |
+//! | `TURBOLITE_CACHE_DIR` | no | `"."` (local) / `"/tmp/turbolite"` (s3) | Lower-level cache directory; ignored when `TURBOLITE_DATABASE_PATH` is set. |
 //! | `TURBOLITE_ENDPOINT_URL` | no | — | Custom S3 endpoint (Tigris, MinIO) |
 //! | `TURBOLITE_REGION` | no | — | AWS region |
 //! | `TURBOLITE_PREFETCH_THREADS` | no | `num_cpus + 1` | Prefetch worker threads |
@@ -291,14 +298,18 @@ fn register_local() -> Result<(), std::io::Error> {
     use std::path::PathBuf;
     use turbolite::tiered::{TurboliteConfig, TurboliteVfs};
 
-    // Loadable extensions preserve the historical "." cache_dir fallback when
-    // TURBOLITE_CACHE_DIR is unset. Everything else comes from the env-driven
-    // constructor.
-    let config = TurboliteConfig {
-        cache_dir: std::env::var("TURBOLITE_CACHE_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from(".")),
-        ..TurboliteConfig::from_env()
+    // File-first when TURBOLITE_DATABASE_PATH is set: the env-supplied path
+    // becomes the local page image and the sidecar lives at
+    // `<path>-turbolite/`. Otherwise fall back to the historical "."
+    // cache_dir behavior so existing test-extension callers keep working.
+    let config = match std::env::var("TURBOLITE_DATABASE_PATH").map(PathBuf::from) {
+        Ok(db_path) => TurboliteConfig::for_database_path(db_path),
+        Err(_) => TurboliteConfig {
+            cache_dir: std::env::var("TURBOLITE_CACHE_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| PathBuf::from(".")),
+            ..TurboliteConfig::from_env()
+        },
     };
     let vfs = TurboliteVfs::new_local(config)?;
     turbolite::tiered::register("turbolite", vfs)
@@ -341,9 +352,12 @@ fn register_tiered() -> Result<(), std::io::Error> {
         counters.base_put_bytes = 0;
     }
 
-    let config = TurboliteConfig {
-        cache_dir,
-        ..TurboliteConfig::from_env()
+    let config = match std::env::var("TURBOLITE_DATABASE_PATH").map(PathBuf::from) {
+        Ok(db_path) => TurboliteConfig::for_database_path(db_path),
+        Err(_) => TurboliteConfig {
+            cache_dir,
+            ..TurboliteConfig::from_env()
+        },
     };
     turbolite::tiered::set_local_checkpoint_only(
         std::env::var("TURBOLITE_LOCAL_THEN_FLUSH")
@@ -696,6 +710,13 @@ pub extern "C" fn turbolite_gc() -> i32 {
 /// Called from SQL: SELECT turbolite_register_vfs('name', '/path/to/cache_dir').
 /// Each registered VFS gets its own manifest, cache, and page group state,
 /// enabling multiple independent databases in the same process.
+///
+/// This is the lower-level form: turbolite owns the entire `cache_dir` and
+/// stores the local database image at `<cache_dir>/data.cache`. Bindings that
+/// expose a user-facing `app.db` should prefer
+/// [`turbolite_ext_register_file_first_vfs`] so the user's database path is
+/// the local image.
+///
 /// Returns 0 on success, 1 on error.
 #[no_mangle]
 pub extern "C" fn turbolite_ext_register_named_vfs(
@@ -729,6 +750,60 @@ pub extern "C" fn turbolite_ext_register_named_vfs(
         },
         Err(e) => {
             eprintln!("turbolite: failed to create VFS '{}': {}", name, e);
+            1
+        }
+    }
+}
+
+/// Register a file-first local VFS keyed to a database path.
+///
+/// Called from SQL via:
+///
+/// ```sql
+/// SELECT turbolite_register_file_first_vfs('app', '/data/app.db');
+/// ```
+///
+/// The caller's `db_path` becomes the local database image and turbolite
+/// stores its sidecar metadata at `<db_path>-turbolite/`. This is the
+/// recommended user-facing entry point — bindings should expose this rather
+/// than the bare `cache_dir`-driven [`turbolite_ext_register_named_vfs`].
+///
+/// Returns 0 on success, 1 on error.
+#[no_mangle]
+pub extern "C" fn turbolite_ext_register_file_first_vfs(
+    name_ptr: *const std::os::raw::c_char,
+    db_path_ptr: *const std::os::raw::c_char,
+) -> std::os::raw::c_int {
+    let name = unsafe {
+        match std::ffi::CStr::from_ptr(name_ptr).to_str() {
+            Ok(s) => s.to_string(),
+            Err(_) => return 1,
+        }
+    };
+    let db_path = unsafe {
+        match std::ffi::CStr::from_ptr(db_path_ptr).to_str() {
+            Ok(s) => std::path::PathBuf::from(s),
+            Err(_) => return 1,
+        }
+    };
+
+    let config = turbolite::tiered::TurboliteConfig::for_database_path(db_path);
+    match turbolite::tiered::TurboliteVfs::new_local(config) {
+        Ok(vfs) => match turbolite::tiered::register(&name, vfs) {
+            Ok(()) => 0,
+            Err(e) => {
+                eprintln!(
+                    "turbolite: failed to register file-first VFS '{}': {}",
+                    name, e
+                );
+                1
+            }
+        },
+        Err(e) => {
+            eprintln!(
+                "turbolite: failed to create file-first VFS '{}': {}",
+                name, e
+            );
             1
         }
     }

--- a/turbolite-ffi/src/ext_entry.c
+++ b/turbolite-ffi/src/ext_entry.c
@@ -29,6 +29,11 @@ extern int turbolite_ext_register_vfs(void);
  * Defined in src/ext.rs. */
 extern int turbolite_ext_register_named_vfs(const char *name, const char *cache_dir);
 
+/* Rust function -- registers a file-first local VFS keyed to a database
+ * path. The caller's path is the local page image; sidecar metadata lives
+ * at `<db_path>-turbolite/`. Defined in src/ext.rs. */
+extern int turbolite_ext_register_file_first_vfs(const char *name, const char *db_path);
+
 /* Rust function -- runs EQP on SQL and pushes plan to global queue.
  * Defined in src/tiered/query_plan.rs. */
 extern void turbolite_trace_push_plan(sqlite3 *db, const char *sql);
@@ -77,10 +82,11 @@ extern int turbolite_evict_query(sqlite3 *db, const char *sql);
 /*
  * turbolite_register_vfs(name TEXT, cache_dir TEXT)
  *
- * Register a named local VFS with isolated state.
- * Each call creates a new VFS instance with its own manifest, cache,
- * and page group state. This enables multiple independent databases
- * in the same process via the loadable extension.
+ * Lower-level: register a named local VFS with isolated state under a
+ * caller-owned cache directory. Each call creates a new VFS instance with
+ * its own manifest, cache, and page group state. The local database image
+ * is stored at `<cache_dir>/data.cache`. Bindings that expose a user-facing
+ * `app.db` should call `turbolite_register_file_first_vfs` instead.
  *
  * Example: SELECT turbolite_register_vfs('turbolite-0', '/path/to/dbdir');
  * Then:    sqlite3_open_v2("file:db?vfs=turbolite-0", ...)
@@ -100,6 +106,37 @@ static void turbolite_register_vfs_func(
         return;
     }
     int rc = turbolite_ext_register_named_vfs(name, cache_dir);
+    sqlite3_result_int(ctx, rc);
+}
+
+/*
+ * turbolite_register_file_first_vfs(name TEXT, db_path TEXT)
+ *
+ * Register a file-first local VFS keyed to a database path. The caller's
+ * `db_path` is the local page image; sidecar metadata lives under
+ * `<db_path>-turbolite/`. This is the recommended user-facing entry point.
+ *
+ * Example: SELECT turbolite_register_file_first_vfs('app', '/data/app.db');
+ * Then:    sqlite3_open_v2("/data/app.db", ..., "app");
+ *
+ * Returns 0 on success, 1 on error.
+ */
+static void turbolite_register_file_first_vfs_func(
+    sqlite3_context *ctx,
+    int argc,
+    sqlite3_value **argv
+) {
+    (void)argc;
+    const char *name = (const char *)sqlite3_value_text(argv[0]);
+    const char *db_path = (const char *)sqlite3_value_text(argv[1]);
+    if (!name || !db_path) {
+        sqlite3_result_error(
+            ctx,
+            "turbolite_register_file_first_vfs: name and db_path required",
+            -1);
+        return;
+    }
+    int rc = turbolite_ext_register_file_first_vfs(name, db_path);
     sqlite3_result_int(ctx, rc);
 }
 
@@ -477,6 +514,19 @@ int turbolite_c_sqlite3_turbolite_init(
     );
     if (rc != SQLITE_OK) {
         *pzErrMsg = sqlite3_mprintf("turbolite: failed to register turbolite_register_vfs()");
+        return rc;
+    }
+
+    /* register turbolite_register_file_first_vfs(name, db_path) SQL function.
+     * File-first registration: the caller's db_path is the local page image
+     * and sidecar metadata lives at <db_path>-turbolite/. */
+    rc = sqlite3_create_function_v2(
+        db, "turbolite_register_file_first_vfs", 2,
+        SQLITE_UTF8, 0, turbolite_register_file_first_vfs_func, 0, 0, 0
+    );
+    if (rc != SQLITE_OK) {
+        *pzErrMsg = sqlite3_mprintf(
+            "turbolite: failed to register turbolite_register_file_first_vfs()");
         return rc;
     }
 

--- a/turbolite-ffi/src/ffi.rs
+++ b/turbolite-ffi/src/ffi.rs
@@ -248,9 +248,10 @@ pub extern "C" fn turbolite_state_dir_for_database_path(
 /// { "local_data_path": "/data/app.db" }
 /// ```
 ///
-/// turbolite owns `app.db` as the local page image; sidecar metadata lives
-/// next to it under `app.db-turbolite/`. The optional `cache_dir` field
-/// overrides the derived sidecar location.
+/// turbolite owns `app.db` as the local page image; the sidecar lives next
+/// to it under `app.db-turbolite/`. When `local_data_path` is set and
+/// `cache_dir` is *not* supplied, the sidecar path is derived from
+/// `local_data_path`. To pin the sidecar somewhere else, set both fields.
 ///
 /// # Lower-level local mode
 ///
@@ -288,13 +289,42 @@ pub extern "C" fn turbolite_register(name: *const c_char, config_json: *const c_
         Err(code) => return code,
     };
 
-    let config: turbolite::tiered::TurboliteConfig = match serde_json::from_str(config_json) {
+    // Parse to a Value first so we can detect whether `cache_dir` was
+    // explicitly supplied; if `local_data_path` is set without an explicit
+    // `cache_dir`, derive the file-first sidecar path from local_data_path.
+    let raw: serde_json::Value = match serde_json::from_str(config_json) {
+        Ok(v) => v,
+        Err(e) => {
+            set_last_error(&format!("invalid config JSON: {}", e));
+            return -1;
+        }
+    };
+    let cache_dir_present = raw
+        .get("cache_dir")
+        .map(|v| !v.is_null())
+        .unwrap_or(false);
+    let local_data_path_present = raw
+        .get("local_data_path")
+        .map(|v| !v.is_null())
+        .unwrap_or(false);
+
+    let mut config: turbolite::tiered::TurboliteConfig = match serde_json::from_value(raw) {
         Ok(c) => c,
         Err(e) => {
             set_last_error(&format!("invalid config JSON: {}", e));
             return -1;
         }
     };
+
+    if local_data_path_present && !cache_dir_present {
+        if let Some(db_path) = config.local_data_path.clone() {
+            config.cache_dir =
+                turbolite::tiered::TurboliteConfig::state_dir_for_database_path(
+                    &db_path,
+                    "-turbolite",
+                );
+        }
+    }
 
     let vfs = match turbolite::tiered::TurboliteVfs::new_local(config) {
         Ok(v) => v,

--- a/turbolite-ffi/src/ffi.rs
+++ b/turbolite-ffi/src/ffi.rs
@@ -19,18 +19,25 @@
 //! #include "turbolite.h"
 //! #include <sqlite3.h>
 //!
-//! // Register the VFS (local mode)
-//! int rc = turbolite_register_local("turbolite", "/data/mydb", 3);
+//! // Recommended file-first registration: the caller's database path is
+//! // the local page image. Sidecar metadata lives in `/data/app.db-turbolite/`.
+//! int rc = turbolite_register_local_file_first("turbolite", "/data/app.db", 3);
 //! if (rc != 0) {
 //!     fprintf(stderr, "error: %s\n", turbolite_last_error());
 //! }
 //!
-//! // Or use JSON config for full control:
-//! // int rc = turbolite_register("turbolite", "{\"cache_dir\": \"/data/mydb\"}");
-//!
-//! // Open a database using the registered VFS
 //! sqlite3 *db;
-//! sqlite3_open_v2("mydb.sqlite", &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, "turbolite");
+//! sqlite3_open_v2("/data/app.db", &db,
+//!                 SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, "turbolite");
+//!
+//! // Lower-level: pass a cache directory and let turbolite store the
+//! // page image under `<cache_dir>/data.cache`. Useful when the caller
+//! // wants to manage the cache layout themselves.
+//! // int rc = turbolite_register_local("turbolite-low", "/data/mydb", 3);
+//!
+//! // JSON config for full control (file-first):
+//! // turbolite_register("turbolite",
+//! //     "{\"local_data_path\": \"/data/app.db\"}");
 //! ```
 
 use std::cell::RefCell;
@@ -85,14 +92,74 @@ pub extern "C" fn turbolite_version() -> *const c_char {
 
 // --- VFS registration ---
 
-/// Register a local TurboliteVfs (page groups on disk, no S3).
+/// Register a local TurboliteVfs keyed to a database file path (file-first).
 ///
-/// This is the recommended way to create a high-performance local SQLite VFS
-/// with compressed page groups and manifest-based storage.
+/// This is the recommended local registration. The caller's `database_path`
+/// is the primary local database image; turbolite stores its hidden
+/// implementation state under `<database_path>-turbolite/` (manifest, cache,
+/// staging logs, etc.). Bindings should prefer this over
+/// [`turbolite_register_local`].
+///
+/// `database_path` may be relative or absolute. Relative paths are kept
+/// verbatim and resolved against the process working directory at open time.
+/// The string is copied immediately into a `PathBuf`; the caller may free
+/// the buffer after this call returns.
 ///
 /// # Parameters
-/// - `name`: VFS name (e.g. `"turbolite"`). Must be unique.
-/// - `cache_dir`: Directory where page groups and manifest are stored.
+/// - `name`: VFS name (e.g. `"turbolite"`). Must be unique per process.
+/// - `database_path`: User-facing database path (e.g. `/data/app.db`).
+/// - `compression_level`: zstd level 1-22 (3 is a good default).
+///
+/// # Returns
+/// 0 on success, -1 on error. Call `turbolite_last_error()` for details.
+#[no_mangle]
+pub extern "C" fn turbolite_register_local_file_first(
+    name: *const c_char,
+    database_path: *const c_char,
+    compression_level: c_int,
+) -> c_int {
+    clear_last_error();
+    let name = match cstr_to_str(name, "name") {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let database_path = match cstr_to_str(database_path, "database_path") {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+
+    let mut config = turbolite::tiered::TurboliteConfig::for_database_path(database_path);
+    config.compression.level = compression_level;
+    config.compression_level = compression_level;
+
+    let vfs = match turbolite::tiered::TurboliteVfs::new_local(config) {
+        Ok(v) => v,
+        Err(e) => {
+            set_last_error(&format!("local vfs creation failed: {}", e));
+            return -1;
+        }
+    };
+    match turbolite::tiered::register(name, vfs) {
+        Ok(()) => 0,
+        Err(e) => {
+            set_last_error(&format!("register failed: {}", e));
+            -1
+        }
+    }
+}
+
+/// Register a local TurboliteVfs (lower-level: caller picks cache_dir).
+///
+/// Lower-level than [`turbolite_register_local_file_first`]: turbolite owns
+/// the entire `cache_dir` directory and stores the local database image at
+/// `<cache_dir>/data.cache` instead of a caller-supplied file path. Use this
+/// only when you need to control the cache layout directly. New embedders
+/// should prefer the file-first registration so the user-facing artifact is
+/// `app.db`, not `cache_dir/data.cache`.
+///
+/// # Parameters
+/// - `name`: VFS name (e.g. `"turbolite"`). Must be unique per process.
+/// - `cache_dir`: Directory turbolite owns for its page-group storage.
 /// - `compression_level`: zstd level 1-22 (3 is a good default).
 ///
 /// # Returns
@@ -138,23 +205,68 @@ pub extern "C" fn turbolite_register_local(
     }
 }
 
+/// Compute the hidden sidecar directory path for a database file.
+///
+/// Convenience for bindings that want to assert or eagerly create the
+/// sidecar location without re-implementing the suffix rule. For
+/// `database_path = "/data/app.db"` the result is `/data/app.db-turbolite`.
+///
+/// The returned string is heap-allocated; callers must free it with
+/// [`turbolite_free_string`].
+///
+/// Returns NULL if `database_path` is NULL or not valid UTF-8.
+#[no_mangle]
+pub extern "C" fn turbolite_state_dir_for_database_path(
+    database_path: *const c_char,
+) -> *mut c_char {
+    clear_last_error();
+    let database_path = match cstr_to_str(database_path, "database_path") {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let dir = turbolite::tiered::TurboliteConfig::state_dir_for_database_path(
+        database_path,
+        "-turbolite",
+    );
+    match CString::new(dir.to_string_lossy().into_owned()) {
+        Ok(cs) => cs.into_raw(),
+        Err(e) => {
+            set_last_error(&format!("path contains null byte: {}", e));
+            std::ptr::null_mut()
+        }
+    }
+}
+
 /// Register a TurboliteVfs from a JSON configuration string.
 ///
 /// Unified entry point that supports both local and cloud modes. The JSON
 /// object is deserialized into a `TurboliteConfig`. Unknown fields are ignored.
 ///
-/// # Minimal JSON (local mode)
+/// # File-first local mode (recommended)
+///
+/// ```json
+/// { "local_data_path": "/data/app.db" }
+/// ```
+///
+/// turbolite owns `app.db` as the local page image; sidecar metadata lives
+/// next to it under `app.db-turbolite/`. The optional `cache_dir` field
+/// overrides the derived sidecar location.
+///
+/// # Lower-level local mode
 ///
 /// ```json
 /// { "cache_dir": "/data/mydb" }
 /// ```
+///
+/// turbolite owns the directory and stores the page image at
+/// `/data/mydb/data.cache`. Prefer the file-first form for new embedders.
 ///
 /// # Cloud mode
 ///
 /// ```json
 /// {
 ///   "storage_backend": { "S3": { "bucket": "my-bucket", "prefix": "db/" } },
-///   "cache_dir": "/tmp/cache"
+///   "local_data_path": "/data/app.db"
 /// }
 /// ```
 ///

--- a/turbolite-ffi/tests/crash_recovery.rs
+++ b/turbolite-ffi/tests/crash_recovery.rs
@@ -694,3 +694,162 @@ fn test_delete_mode_crash_recovery() {
     assert!(json.contains("ok"), "integrity must pass: {}", json);
     turbolite_close(db);
 }
+
+
+/// Regression test for the lock-downgrade-without-sync rollback bug.
+///
+/// Earlier code in TurboliteHandle::lock() treated "lock downgrades from
+/// EXCLUSIVE/RESERVED with dirty pages but no intervening xSync" as a
+/// signal that the transaction had been rolled back, and discarded the
+/// dirty pages. SQLite skips xSync entirely under PRAGMA synchronous=OFF,
+/// so every commit looked like a rollback and writes were silently
+/// dropped on close+reopen.
+///
+/// This locks the matrix down: every (journal_mode, synchronous) pair
+/// must preserve writes across a clean close + reopen.
+#[test]
+fn test_persistence_across_synchronous_modes() {
+    let cases: &[(&str, &str)] = &[
+        ("WAL", "OFF"),
+        ("WAL", "NORMAL"),
+        ("WAL", "FULL"),
+        ("WAL", "EXTRA"),
+        ("DELETE", "OFF"),
+        ("DELETE", "NORMAL"),
+        ("DELETE", "FULL"),
+        ("TRUNCATE", "OFF"),
+        ("TRUNCATE", "NORMAL"),
+        ("PERSIST", "OFF"),
+        ("PERSIST", "NORMAL"),
+    ];
+
+    for (journal, sync) in cases {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join(format!("persist_{journal}_{sync}.db"));
+        let db_path_str = db_path.to_str().unwrap().to_string();
+
+        let vfs_name = setup_vfs(dir.path());
+
+        let db = open_db(&db_path_str, &vfs_name);
+        exec_sql(db, &format!("PRAGMA journal_mode={journal}"));
+        exec_sql(db, &format!("PRAGMA synchronous={sync}"));
+        exec_sql(
+            db,
+            "CREATE TABLE rows (id INTEGER PRIMARY KEY, val TEXT)",
+        );
+        for i in 0..20 {
+            exec_sql(db, &format!("INSERT INTO rows VALUES ({i}, 'v{i}')"));
+        }
+        // Some configurations checkpoint, others don't; the contract is
+        // that clean-close + reopen preserves data either way.
+        if *journal == "WAL" {
+            exec_sql(db, "PRAGMA wal_checkpoint(TRUNCATE)");
+        }
+        turbolite_close(db);
+
+        let db = open_db(&db_path_str, &vfs_name);
+        let json = query_json(db, "SELECT COUNT(*) as cnt FROM rows");
+        assert!(
+            json.contains("20"),
+            "journal={journal} sync={sync}: lost rows after clean close+reopen: {json}",
+        );
+        let json = query_json(db, "PRAGMA integrity_check");
+        assert!(
+            json.contains("ok"),
+            "journal={journal} sync={sync}: integrity check failed: {json}",
+        );
+        turbolite_close(db);
+    }
+}
+
+/// Regression test for the same bug at a finer granularity: prove that
+/// committing many transactions under sync=OFF preserves every commit,
+/// not just the last. Earlier behavior would discard every commit's
+/// dirty pages at lock-downgrade.
+#[test]
+fn test_synchronous_off_multiple_commits_persist() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("multi_commit.db");
+    let db_path_str = db_path.to_str().unwrap().to_string();
+
+    let vfs_name = setup_vfs(dir.path());
+
+    let db = open_db(&db_path_str, &vfs_name);
+    exec_sql(db, "PRAGMA journal_mode=WAL");
+    exec_sql(db, "PRAGMA synchronous=OFF");
+    exec_sql(db, "CREATE TABLE log (id INTEGER PRIMARY KEY, msg TEXT)");
+
+    // 10 separate commit boundaries — each should survive.
+    for i in 0..10 {
+        exec_sql(db, "BEGIN");
+        for j in 0..5 {
+            exec_sql(
+                db,
+                &format!("INSERT INTO log VALUES ({}, 'tx{i}_{j}')", i * 5 + j),
+            );
+        }
+        exec_sql(db, "COMMIT");
+    }
+    exec_sql(db, "PRAGMA wal_checkpoint(TRUNCATE)");
+    turbolite_close(db);
+
+    let db = open_db(&db_path_str, &vfs_name);
+    let json = query_json(db, "SELECT COUNT(*) as cnt FROM log");
+    assert!(
+        json.contains("50"),
+        "sync=OFF must preserve every commit, expected 50 rows: {json}",
+    );
+    let json = query_json(db, "PRAGMA integrity_check");
+    assert!(json.contains("ok"), "integrity must pass: {}", json);
+    turbolite_close(db);
+}
+
+
+/// Rollback regression: the lock-downgrade-without-sync code path used
+/// to discard dirty pages on the assumption they were rolled-back
+/// in-progress writes. The new behavior unconditionally persists at
+/// lock downgrade. Make sure that's still correct for actual rollbacks
+/// — i.e., the rollback's restored-original page bytes are what end up
+/// persisted, not the in-progress writes.
+#[test]
+fn test_rollback_under_sync_off_keeps_pre_txn_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("rollback.db");
+    let db_path_str = db_path.to_str().unwrap().to_string();
+
+    let vfs_name = setup_vfs(dir.path());
+
+    let db = open_db(&db_path_str, &vfs_name);
+    exec_sql(db, "PRAGMA journal_mode=WAL");
+    exec_sql(db, "PRAGMA synchronous=OFF");
+    exec_sql(db, "CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)");
+    for i in 0..10 {
+        exec_sql(db, &format!("INSERT INTO t VALUES ({i}, 'committed')"));
+    }
+    exec_sql(db, "PRAGMA wal_checkpoint(TRUNCATE)");
+
+    // Now run a transaction that we explicitly rollback.
+    exec_sql(db, "BEGIN");
+    for i in 10..20 {
+        exec_sql(db, &format!("INSERT INTO t VALUES ({i}, 'aborted')"));
+    }
+    exec_sql(db, "ROLLBACK");
+    exec_sql(db, "PRAGMA wal_checkpoint(TRUNCATE)");
+    turbolite_close(db);
+
+    // Reopen: must see only the 10 committed rows; no 'aborted' rows.
+    let db = open_db(&db_path_str, &vfs_name);
+    let json = query_json(db, "SELECT COUNT(*) FROM t");
+    assert!(
+        json.contains("10"),
+        "rollback must not persist aborted rows: {json}",
+    );
+    let json = query_json(db, "SELECT COUNT(*) FROM t WHERE val = 'aborted'");
+    assert!(
+        json.contains(":0") || json.contains(": 0"),
+        "no aborted rows must persist: {json}",
+    );
+    let json = query_json(db, "PRAGMA integrity_check");
+    assert!(json.contains("ok"), "integrity must pass after rollback: {json}");
+    turbolite_close(db);
+}

--- a/turbolite-ffi/tests/ffi_test.rs
+++ b/turbolite-ffi/tests/ffi_test.rs
@@ -188,6 +188,96 @@ fn test_persistence_across_connections() {
     turbolite_close(db);
 }
 
+// --- turbolite_register_local_file_first ---
+
+#[test]
+fn test_register_local_file_first_layout() {
+    // File-first: db_path is the local page image; sidecar metadata lives at
+    // `<db_path>-turbolite/` and the consolidated state file is
+    // local_state.msgpack. Old split tracking files should not appear.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("app.db");
+    let vfs_name = CString::new("ffi-file-first").unwrap();
+    let db_path_c = CString::new(db_path.to_str().unwrap()).unwrap();
+
+    let rc = turbolite_register_local_file_first(vfs_name.as_ptr(), db_path_c.as_ptr(), 3);
+    assert_eq!(rc, 0, "register_local_file_first should succeed");
+
+    let db = turbolite_open(db_path_c.as_ptr(), vfs_name.as_ptr());
+    assert!(!db.is_null(), "open should return non-null handle");
+
+    let sql = CString::new(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT); \
+         INSERT INTO t VALUES (1, 'one'); \
+         INSERT INTO t VALUES (2, 'two');",
+    )
+    .unwrap();
+    assert_eq!(turbolite_exec(db, sql.as_ptr()), 0);
+    turbolite_close(db);
+
+    assert!(db_path.is_file(), "file-first: app.db must exist");
+    let sidecar = dir.path().join("app.db-turbolite");
+    assert!(sidecar.is_dir(), "file-first: sidecar dir must exist");
+
+    let local_state = sidecar.join("local_state.msgpack");
+    assert!(
+        local_state.is_file(),
+        "file-first: local_state.msgpack must exist"
+    );
+
+    // In pure-local mode the local backend still owns its own
+    // `manifest.msgpack` under the sidecar (via the storage client); only the
+    // DiskCache split tracking files are gone. The file-first contract is
+    // about consolidating local cache tracking into local_state.msgpack.
+    for legacy in [
+        "page_bitmap",
+        "sub_chunk_tracker",
+        "cache_index.json",
+        "dirty_groups.msgpack",
+    ] {
+        assert!(
+            !sidecar.join(legacy).is_file(),
+            "file-first: legacy split file {legacy} should not be produced"
+        );
+    }
+
+    // Reopen and read.
+    let db = turbolite_open(db_path_c.as_ptr(), vfs_name.as_ptr());
+    assert!(!db.is_null());
+    let query = CString::new("SELECT * FROM t ORDER BY id").unwrap();
+    let json_ptr = turbolite_query_json(db, query.as_ptr());
+    assert!(!json_ptr.is_null());
+    let json_str = unsafe { std::ffi::CStr::from_ptr(json_ptr) }
+        .to_str()
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(json_str).unwrap();
+    let rows = parsed.as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["val"], "one");
+    assert_eq!(rows[1]["val"], "two");
+    turbolite_free_string(json_ptr);
+    turbolite_close(db);
+}
+
+#[test]
+fn test_state_dir_for_database_path_helper() {
+    let path = CString::new("/tmp/app.db").unwrap();
+    let ptr = turbolite_state_dir_for_database_path(path.as_ptr());
+    assert!(!ptr.is_null());
+    let s = unsafe { std::ffi::CStr::from_ptr(ptr) }
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(s, "/tmp/app.db-turbolite");
+    turbolite_free_string(ptr);
+}
+
+#[test]
+fn test_state_dir_for_database_path_null_returns_null() {
+    let ptr = turbolite_state_dir_for_database_path(std::ptr::null());
+    assert!(ptr.is_null());
+}
+
 // --- turbolite_register_local ---
 
 #[test]

--- a/turbolite-ffi/tests/ffi_test.rs
+++ b/turbolite-ffi/tests/ffi_test.rs
@@ -260,6 +260,88 @@ fn test_register_local_file_first_layout() {
 }
 
 #[test]
+fn test_register_local_file_first_null_name_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = CString::new(dir.path().join("app.db").to_str().unwrap()).unwrap();
+    let rc = turbolite_register_local_file_first(std::ptr::null(), db_path.as_ptr(), 3);
+    assert_eq!(rc, -1);
+    let err = turbolite_last_error();
+    assert!(!err.is_null());
+    let msg = unsafe { std::ffi::CStr::from_ptr(err) }.to_str().unwrap();
+    assert!(msg.contains("name"), "expected 'name' in error: {msg}");
+}
+
+#[test]
+fn test_register_local_file_first_null_database_path_fails() {
+    let name = CString::new("ffi-file-first-null-path").unwrap();
+    let rc = turbolite_register_local_file_first(name.as_ptr(), std::ptr::null(), 3);
+    assert_eq!(rc, -1);
+    let err = turbolite_last_error();
+    assert!(!err.is_null());
+    let msg = unsafe { std::ffi::CStr::from_ptr(err) }.to_str().unwrap();
+    assert!(
+        msg.contains("database_path"),
+        "expected 'database_path' in error: {msg}"
+    );
+}
+
+#[test]
+fn test_register_local_file_first_honors_compression_level() {
+    // Regression test: the file-first FFI helper must apply the
+    // compression_level argument the same way the lower-level helper does.
+    // Build with two different levels and confirm both succeed end-to-end.
+    let dir = tempfile::tempdir().unwrap();
+    for (suffix, level) in [("a", 1), ("b", 22)] {
+        let db_path = dir.path().join(format!("app-{suffix}.db"));
+        let vfs = CString::new(format!("ffi-file-first-comp-{suffix}")).unwrap();
+        let dbp = CString::new(db_path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            turbolite_register_local_file_first(vfs.as_ptr(), dbp.as_ptr(), level),
+            0,
+            "level={level} must succeed"
+        );
+        let db = turbolite_open(dbp.as_ptr(), vfs.as_ptr());
+        assert!(!db.is_null());
+        let sql = CString::new("CREATE TABLE t (i INTEGER); INSERT INTO t VALUES (1);").unwrap();
+        assert_eq!(turbolite_exec(db, sql.as_ptr()), 0);
+        turbolite_close(db);
+        assert!(db_path.is_file());
+    }
+}
+
+#[test]
+fn test_register_local_file_first_rejects_alias_open() {
+    // File-first VFS identity contract: opening a different filename
+    // through the same VFS must be rejected. This proves the binding
+    // layer can rely on per-VFS path identity for isolation.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("app.db");
+    let other_path = dir.path().join("other.db");
+    let vfs_name = CString::new("ffi-file-first-alias").unwrap();
+    let db_path_c = CString::new(db_path.to_str().unwrap()).unwrap();
+    let other_path_c = CString::new(other_path.to_str().unwrap()).unwrap();
+
+    assert_eq!(
+        turbolite_register_local_file_first(vfs_name.as_ptr(), db_path_c.as_ptr(), 3),
+        0
+    );
+
+    // Opening the registered path is fine.
+    let db = turbolite_open(db_path_c.as_ptr(), vfs_name.as_ptr());
+    assert!(!db.is_null(), "registered path must open");
+    turbolite_close(db);
+
+    // Opening a different path through the same VFS must fail.
+    let aliased = turbolite_open(other_path_c.as_ptr(), vfs_name.as_ptr());
+    assert!(
+        aliased.is_null(),
+        "file-first VFS must reject mismatched alias open"
+    );
+    let err = turbolite_last_error();
+    assert!(!err.is_null());
+}
+
+#[test]
 fn test_state_dir_for_database_path_helper() {
     let path = CString::new("/tmp/app.db").unwrap();
     let ptr = turbolite_state_dir_for_database_path(path.as_ptr());

--- a/turbolite-ffi/tests/ffi_test.rs
+++ b/turbolite-ffi/tests/ffi_test.rs
@@ -278,6 +278,65 @@ fn test_state_dir_for_database_path_null_returns_null() {
     assert!(ptr.is_null());
 }
 
+#[test]
+fn test_register_json_local_data_path_derives_sidecar() {
+    // When the JSON config sets `local_data_path` but not `cache_dir`,
+    // the sidecar must end up at `<local_data_path>-turbolite/`, not at
+    // the default `/tmp/turbolite-cache`.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("derived.db");
+    let name = CString::new("ffi-json-file-first-derive").unwrap();
+    let config = format!(
+        r#"{{ "local_data_path": "{}" }}"#,
+        db_path.to_str().unwrap()
+    );
+    let config_json = CString::new(config).unwrap();
+    let rc = turbolite_register(name.as_ptr(), config_json.as_ptr());
+    assert_eq!(rc, 0);
+
+    let db_path_c = CString::new(db_path.to_str().unwrap()).unwrap();
+    let db = turbolite_open(db_path_c.as_ptr(), name.as_ptr());
+    assert!(!db.is_null());
+    let sql = CString::new("CREATE TABLE t (id INTEGER); INSERT INTO t VALUES (1);").unwrap();
+    assert_eq!(turbolite_exec(db, sql.as_ptr()), 0);
+    turbolite_close(db);
+
+    let sidecar = dir.path().join("derived.db-turbolite");
+    assert!(
+        sidecar.is_dir(),
+        "JSON local_data_path-only must derive sidecar next to db",
+    );
+    assert!(sidecar.join("local_state.msgpack").is_file());
+}
+
+#[test]
+fn test_register_json_local_data_path_with_explicit_cache_dir() {
+    // When BOTH fields are set, `cache_dir` wins (no auto-derivation).
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("explicit.db");
+    let custom_sidecar = dir.path().join("custom-sidecar");
+    std::fs::create_dir_all(&custom_sidecar).unwrap();
+    let name = CString::new("ffi-json-file-first-explicit").unwrap();
+    let config = format!(
+        r#"{{ "local_data_path": "{}", "cache_dir": "{}" }}"#,
+        db_path.to_str().unwrap(),
+        custom_sidecar.to_str().unwrap()
+    );
+    let config_json = CString::new(config).unwrap();
+    assert_eq!(turbolite_register(name.as_ptr(), config_json.as_ptr()), 0);
+
+    let db_path_c = CString::new(db_path.to_str().unwrap()).unwrap();
+    let db = turbolite_open(db_path_c.as_ptr(), name.as_ptr());
+    assert!(!db.is_null());
+    let sql = CString::new("CREATE TABLE t (id INTEGER); INSERT INTO t VALUES (1);").unwrap();
+    assert_eq!(turbolite_exec(db, sql.as_ptr()), 0);
+    turbolite_close(db);
+
+    assert!(custom_sidecar.join("local_state.msgpack").is_file());
+    // No auto-derived sidecar at the default location.
+    assert!(!dir.path().join("explicit.db-turbolite").exists());
+}
+
 // --- turbolite_register_local ---
 
 #[test]

--- a/turbolite-ffi/tests/test_ffi_c.c
+++ b/turbolite-ffi/tests/test_ffi_c.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 static int passed = 0;
@@ -210,6 +211,77 @@ static void test_persistence(void) {
 cleanup:;
 }
 
+static int file_exists(const char *path) {
+    struct stat st;
+    return stat(path, &st) == 0 && S_ISREG(st.st_mode);
+}
+
+static int dir_exists(const char *path) {
+    struct stat st;
+    return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+static void test_register_local_file_first(void) {
+    TEST("file-first: register, CRUD, layout, reopen");
+    const char *dir = make_tmpdir();
+    ASSERT(dir != NULL);
+
+    char db_path[512];
+    snprintf(db_path, sizeof(db_path), "%s/app.db", dir);
+
+    /* File-first registration: db_path is the local page image. */
+    int rc = turbolite_register_local_file_first("c-file-first", db_path, 3);
+    ASSERT(rc == 0);
+
+    void *db = turbolite_open(db_path, "c-file-first");
+    ASSERT(db != NULL);
+
+    turbolite_exec(db, "CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);"
+                       "INSERT INTO t VALUES (1, 'one');"
+                       "INSERT INTO t VALUES (2, 'two');");
+    turbolite_close(db);
+
+    /* app.db is the user-visible artifact. */
+    ASSERT(file_exists(db_path));
+
+    /* Sidecar dir + consolidated local-state file. */
+    char sidecar[512];
+    snprintf(sidecar, sizeof(sidecar), "%s/app.db-turbolite", dir);
+    ASSERT(dir_exists(sidecar));
+
+    char *expected_sidecar = turbolite_state_dir_for_database_path(db_path);
+    ASSERT(expected_sidecar != NULL);
+    ASSERT(strcmp(expected_sidecar, sidecar) == 0);
+    turbolite_free_string(expected_sidecar);
+
+    char local_state[512];
+    snprintf(local_state, sizeof(local_state), "%s/local_state.msgpack", sidecar);
+    ASSERT(file_exists(local_state));
+
+    /* Pre-PR-#27 split tracking files must not be required. */
+    const char *legacy[] = {
+        "page_bitmap", "sub_chunk_tracker", "cache_index.json",
+        "dirty_groups.msgpack",
+    };
+    for (size_t i = 0; i < sizeof(legacy) / sizeof(legacy[0]); i++) {
+        char p[512];
+        snprintf(p, sizeof(p), "%s/%s", sidecar, legacy[i]);
+        ASSERT(!file_exists(p));
+    }
+
+    /* Reopen and verify data. */
+    db = turbolite_open(db_path, "c-file-first");
+    ASSERT(db != NULL);
+    char *json = turbolite_query_json(db, "SELECT id, val FROM t ORDER BY id");
+    ASSERT(json != NULL);
+    ASSERT(strstr(json, "\"one\"") != NULL);
+    ASSERT(strstr(json, "\"two\"") != NULL);
+    turbolite_free_string(json);
+    turbolite_close(db);
+    PASS();
+cleanup:;
+}
+
 static void test_null_safety(void) {
     TEST("NULL handles don't crash");
     turbolite_close(NULL);
@@ -310,6 +382,7 @@ int main(void) {
     test_version();
     test_null_args();
     test_register_compressed();
+    test_register_local_file_first();
     test_open_close();
     test_exec();
     test_bad_sql();

--- a/turbolite-ffi/tests/test_loadable_ext.py
+++ b/turbolite-ffi/tests/test_loadable_ext.py
@@ -494,6 +494,155 @@ def _():
         conn.close()
 
 
+# ── File-first SQL function: turbolite_register_file_first_vfs ────
+
+
+@test("turbolite_register_file_first_vfs(name, db_path) registers a file-first VFS")
+def _():
+    with tempfile.TemporaryDirectory() as d:
+        db_path = os.path.join(d, "app.db")
+        boot = sqlite3.connect(":memory:")
+        load_ext(boot)
+        rc = boot.execute(
+            "SELECT turbolite_register_file_first_vfs(?, ?)",
+            (f"file-first-sql-{os.getpid()}", db_path),
+        ).fetchone()[0]
+        assert rc == 0, f"register failed with rc={rc}"
+        boot.close()
+
+        # Open through the registered VFS and write data.
+        conn = sqlite3.connect(
+            f"file:{db_path}?vfs=file-first-sql-{os.getpid()}", uri=True
+        )
+        conn.execute("CREATE TABLE t (i INTEGER)")
+        conn.execute("INSERT INTO t VALUES (1)")
+        conn.commit()
+        conn.close()
+
+        assert os.path.isfile(db_path)
+        sidecar = db_path + "-turbolite"
+        assert os.path.isdir(sidecar)
+        assert os.path.isfile(os.path.join(sidecar, "local_state.msgpack"))
+
+
+@test("turbolite_register_file_first_vfs requires both name and db_path")
+def _():
+    boot = sqlite3.connect(":memory:")
+    load_ext(boot)
+    # Both args required — passing NULL surfaces as a SQL error.
+    raised = False
+    try:
+        boot.execute(
+            "SELECT turbolite_register_file_first_vfs(NULL, '/tmp/x')"
+        ).fetchone()
+    except sqlite3.OperationalError as e:
+        raised = "name and db_path required" in str(e)
+    assert raised, "NULL name must surface error"
+
+    raised = False
+    try:
+        boot.execute(
+            "SELECT turbolite_register_file_first_vfs('x', NULL)"
+        ).fetchone()
+    except sqlite3.OperationalError as e:
+        raised = "name and db_path required" in str(e)
+    assert raised, "NULL db_path must surface error"
+    boot.close()
+
+
+# ── TURBOLITE_DATABASE_PATH env var (file-first default VFS) ──────
+
+
+@test("TURBOLITE_DATABASE_PATH respects other TURBOLITE_* env knobs (read-only)")
+def _():
+    # Regression test: file-first registration must keep applying
+    # TurboliteConfig::from_env() so other env vars (TURBOLITE_READ_ONLY,
+    # compression, prefetch) are still honored. Verify by setting
+    # TURBOLITE_READ_ONLY=true and confirming writes are rejected.
+    import subprocess
+    import textwrap
+    with tempfile.TemporaryDirectory() as d:
+        db_path = os.path.join(d, "ro.db")
+
+        seed_src = textwrap.dedent(f"""
+            import os, sqlite3
+            os.environ['TURBOLITE_DATABASE_PATH'] = {db_path!r}
+            boot = sqlite3.connect(':memory:')
+            boot.enable_load_extension(True)
+            boot.load_extension({EXT_PATH!r})
+            boot.close()
+            app = sqlite3.connect('file:{db_path}?vfs=turbolite', uri=True)
+            app.execute('CREATE TABLE t (v INTEGER)')
+            app.execute('INSERT INTO t VALUES (1)')
+            app.commit()
+            app.close()
+            """)
+        rc = subprocess.run(
+            [sys.executable, "-c", seed_src], capture_output=True, text=True
+        )
+        assert rc.returncode == 0, f"seed failed: {rc.stderr}"
+
+        ro_src = textwrap.dedent(f"""
+            import os, sqlite3, sys
+            os.environ['TURBOLITE_DATABASE_PATH'] = {db_path!r}
+            os.environ['TURBOLITE_READ_ONLY'] = 'true'
+            boot = sqlite3.connect(':memory:')
+            boot.enable_load_extension(True)
+            boot.load_extension({EXT_PATH!r})
+            boot.close()
+            app = sqlite3.connect('file:{db_path}?vfs=turbolite', uri=True)
+            ok = False
+            try:
+                app.execute('INSERT INTO t VALUES (2)')
+                app.commit()
+            except sqlite3.OperationalError:
+                # Any failure to write under TURBOLITE_READ_ONLY=true is a
+                # signal that the env var was applied to the file-first config.
+                # Turbolite surfaces read-only writes as "disk I/O error".
+                ok = True
+            app.close()
+            sys.exit(0 if ok else 1)
+            """)
+        rc = subprocess.run(
+            [sys.executable, "-c", ro_src], capture_output=True, text=True
+        )
+        assert rc.returncode == 0, (
+            f"read-only env var was not honored in file-first mode: "
+            f"stderr={rc.stderr} stdout={rc.stdout}"
+        )
+
+
+@test("TURBOLITE_DATABASE_PATH triggers file-first layout for default VFS")
+def _():
+    # The extension is process-loaded once; env vars only matter on first
+    # init. This test forks a fresh Python so it sees a clean process.
+    with tempfile.TemporaryDirectory() as d:
+        db_path = os.path.join(d, "envapp.db")
+        script = (
+            "import os, sqlite3, sys; "
+            f"os.environ['TURBOLITE_DATABASE_PATH'] = {db_path!r}; "
+            "conn = sqlite3.connect(':memory:'); "
+            "conn.enable_load_extension(True); "
+            f"conn.load_extension({EXT_PATH!r}); "
+            "conn.close(); "
+            f"app = sqlite3.connect('file:{db_path}?vfs=turbolite', uri=True); "
+            "app.execute('CREATE TABLE t (i INTEGER)'); "
+            "app.execute('INSERT INTO t VALUES (42)'); "
+            "app.commit(); app.close(); "
+            f"assert os.path.isfile({db_path!r}), 'app.db missing'; "
+            f"assert os.path.isdir({db_path!r} + '-turbolite'), 'sidecar missing'"
+        )
+        import subprocess
+        rc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert rc.returncode == 0, (
+            f"subprocess failed: {rc.stderr}\nstdout: {rc.stdout}"
+        )
+
+
 # ── Summary ───────────────────────────────────────────────────────
 
 

--- a/turbolite-ffi/turbolite.h
+++ b/turbolite-ffi/turbolite.h
@@ -131,9 +131,10 @@ char *turbolite_state_dir_for_database_path(const char *database_path);
  * { "local_data_path": "/data/app.db" }
  * ```
  *
- * turbolite owns `app.db` as the local page image; sidecar metadata lives
- * next to it under `app.db-turbolite/`. The optional `cache_dir` field
- * overrides the derived sidecar location.
+ * turbolite owns `app.db` as the local page image; the sidecar lives next
+ * to it under `app.db-turbolite/`. When `local_data_path` is set and
+ * `cache_dir` is *not* supplied, the sidecar path is derived from
+ * `local_data_path`. To pin the sidecar somewhere else, set both fields.
  *
  * # Lower-level local mode
  *
@@ -271,6 +272,14 @@ void turbolite_free_string(char *s);
  * Close a database connection opened with `turbolite_open`.
  */
 void turbolite_close(struct TurboliteDb *db);
+#endif
+
+#if defined(TURBOLITE_LOADABLE_EXTENSION)
+extern int turbolite_sqlite3_turbolite_init_impl(void *db, char **pz_err_msg, const void *p_api);
+#endif
+
+#if defined(TURBOLITE_LOADABLE_EXTENSION)
+int sqlite3_turbolite_init(void *db, char **pz_err_msg, const void *p_api);
 #endif
 
 #if defined(TURBOLITE_LOADABLE_EXTENSION)
@@ -452,6 +461,10 @@ int turbolite_ext_register_named_vfs(const char *name_ptr, const char *cache_dir
  * stores its sidecar metadata at `<db_path>-turbolite/`. This is the
  * recommended user-facing entry point — bindings should expose this rather
  * than the bare `cache_dir`-driven [`turbolite_ext_register_named_vfs`].
+ *
+ * Other `TURBOLITE_*` env vars (compression, cache, prefetch, read-only)
+ * are honored via `TurboliteConfig::from_env()`; only the cache_dir is
+ * overridden to match the database path.
  *
  * Returns 0 on success, 1 on error.
  */

--- a/turbolite-ffi/turbolite.h
+++ b/turbolite-ffi/turbolite.h
@@ -54,14 +54,46 @@ const char *turbolite_version(void);
 
 #if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
- * Register a local TurboliteVfs (page groups on disk, no S3).
+ * Register a local TurboliteVfs keyed to a database file path (file-first).
  *
- * This is the recommended way to create a high-performance local SQLite VFS
- * with compressed page groups and manifest-based storage.
+ * This is the recommended local registration. The caller's `database_path`
+ * is the primary local database image; turbolite stores its hidden
+ * implementation state under `<database_path>-turbolite/` (manifest, cache,
+ * staging logs, etc.). Bindings should prefer this over
+ * [`turbolite_register_local`].
+ *
+ * `database_path` may be relative or absolute. Relative paths are kept
+ * verbatim and resolved against the process working directory at open time.
+ * The string is copied immediately into a `PathBuf`; the caller may free
+ * the buffer after this call returns.
  *
  * # Parameters
- * - `name`: VFS name (e.g. `"turbolite"`). Must be unique.
- * - `cache_dir`: Directory where page groups and manifest are stored.
+ * - `name`: VFS name (e.g. `"turbolite"`). Must be unique per process.
+ * - `database_path`: User-facing database path (e.g. `/data/app.db`).
+ * - `compression_level`: zstd level 1-22 (3 is a good default).
+ *
+ * # Returns
+ * 0 on success, -1 on error. Call `turbolite_last_error()` for details.
+ */
+int turbolite_register_local_file_first(const char *name,
+                                        const char *database_path,
+                                        int compression_level);
+#endif
+
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
+/**
+ * Register a local TurboliteVfs (lower-level: caller picks cache_dir).
+ *
+ * Lower-level than [`turbolite_register_local_file_first`]: turbolite owns
+ * the entire `cache_dir` directory and stores the local database image at
+ * `<cache_dir>/data.cache` instead of a caller-supplied file path. Use this
+ * only when you need to control the cache layout directly. New embedders
+ * should prefer the file-first registration so the user-facing artifact is
+ * `app.db`, not `cache_dir/data.cache`.
+ *
+ * # Parameters
+ * - `name`: VFS name (e.g. `"turbolite"`). Must be unique per process.
+ * - `cache_dir`: Directory turbolite owns for its page-group storage.
  * - `compression_level`: zstd level 1-22 (3 is a good default).
  *
  * # Returns
@@ -72,23 +104,52 @@ int turbolite_register_local(const char *name, const char *cache_dir, int compre
 
 #if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
+ * Compute the hidden sidecar directory path for a database file.
+ *
+ * Convenience for bindings that want to assert or eagerly create the
+ * sidecar location without re-implementing the suffix rule. For
+ * `database_path = "/data/app.db"` the result is `/data/app.db-turbolite`.
+ *
+ * The returned string is heap-allocated; callers must free it with
+ * [`turbolite_free_string`].
+ *
+ * Returns NULL if `database_path` is NULL or not valid UTF-8.
+ */
+char *turbolite_state_dir_for_database_path(const char *database_path);
+#endif
+
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
+/**
  * Register a TurboliteVfs from a JSON configuration string.
  *
  * Unified entry point that supports both local and cloud modes. The JSON
  * object is deserialized into a `TurboliteConfig`. Unknown fields are ignored.
  *
- * # Minimal JSON (local mode)
+ * # File-first local mode (recommended)
+ *
+ * ```json
+ * { "local_data_path": "/data/app.db" }
+ * ```
+ *
+ * turbolite owns `app.db` as the local page image; sidecar metadata lives
+ * next to it under `app.db-turbolite/`. The optional `cache_dir` field
+ * overrides the derived sidecar location.
+ *
+ * # Lower-level local mode
  *
  * ```json
  * { "cache_dir": "/data/mydb" }
  * ```
+ *
+ * turbolite owns the directory and stores the page image at
+ * `/data/mydb/data.cache`. Prefer the file-first form for new embedders.
  *
  * # Cloud mode
  *
  * ```json
  * {
  *   "storage_backend": { "S3": { "bucket": "my-bucket", "prefix": "db/" } },
- *   "cache_dir": "/tmp/cache"
+ *   "local_data_path": "/data/app.db"
  * }
  * ```
  *
@@ -365,9 +426,36 @@ int32_t turbolite_gc(void);
  * Called from SQL: SELECT turbolite_register_vfs('name', '/path/to/cache_dir').
  * Each registered VFS gets its own manifest, cache, and page group state,
  * enabling multiple independent databases in the same process.
+ *
+ * This is the lower-level form: turbolite owns the entire `cache_dir` and
+ * stores the local database image at `<cache_dir>/data.cache`. Bindings that
+ * expose a user-facing `app.db` should prefer
+ * [`turbolite_ext_register_file_first_vfs`] so the user's database path is
+ * the local image.
+ *
  * Returns 0 on success, 1 on error.
  */
 int turbolite_ext_register_named_vfs(const char *name_ptr, const char *cache_dir_ptr);
+#endif
+
+#if defined(TURBOLITE_LOADABLE_EXTENSION)
+/**
+ * Register a file-first local VFS keyed to a database path.
+ *
+ * Called from SQL via:
+ *
+ * ```sql
+ * SELECT turbolite_register_file_first_vfs('app', '/data/app.db');
+ * ```
+ *
+ * The caller's `db_path` becomes the local database image and turbolite
+ * stores its sidecar metadata at `<db_path>-turbolite/`. This is the
+ * recommended user-facing entry point — bindings should expose this rather
+ * than the bare `cache_dir`-driven [`turbolite_ext_register_named_vfs`].
+ *
+ * Returns 0 on success, 1 on error.
+ */
+int turbolite_ext_register_file_first_vfs(const char *name_ptr, const char *db_path_ptr);
 #endif
 
 /**

--- a/turbolite.h
+++ b/turbolite.h
@@ -13,66 +13,143 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-/**
- * Minimum confidence to fire a prediction.
- */
-#define CONFIDENCE_THRESHOLD 0.5
+typedef struct Option_CreateFnDestroy Option_CreateFnDestroy;
 
+typedef struct Option_CreateFnFinal Option_CreateFnFinal;
+
+typedef struct Option_CreateFnStep Option_CreateFnStep;
+
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Opaque database connection handle.
  */
 typedef struct TurboliteDb TurboliteDb;
+#endif
+
+typedef void sqlite3;
+
+typedef void sqlite3_context;
+
+typedef void sqlite3_value;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Get the last error message, or NULL if no error occurred.
  *
  * The returned pointer is valid until the next turbolite_* call on this thread.
  */
 const char *turbolite_last_error(void);
+#endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Get the turbolite version string. Always returns a valid pointer.
  */
 const char *turbolite_version(void);
+#endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
- * Register a local TurboliteVfs (page groups on disk, no S3).
+ * Register a local TurboliteVfs keyed to a database file path (file-first).
  *
- * This is the recommended way to create a high-performance local SQLite VFS
- * with compressed page groups and manifest-based storage.
+ * This is the recommended local registration. The caller's `database_path`
+ * is the primary local database image; turbolite stores its hidden
+ * implementation state under `<database_path>-turbolite/` (manifest, cache,
+ * staging logs, etc.). Bindings should prefer this over
+ * [`turbolite_register_local`].
+ *
+ * `database_path` may be relative or absolute. Relative paths are kept
+ * verbatim and resolved against the process working directory at open time.
+ * The string is copied immediately into a `PathBuf`; the caller may free
+ * the buffer after this call returns.
  *
  * # Parameters
- * - `name`: VFS name (e.g. `"turbolite"`). Must be unique.
- * - `cache_dir`: Directory where page groups and manifest are stored.
+ * - `name`: VFS name (e.g. `"turbolite"`). Must be unique per process.
+ * - `database_path`: User-facing database path (e.g. `/data/app.db`).
+ * - `compression_level`: zstd level 1-22 (3 is a good default).
+ *
+ * # Returns
+ * 0 on success, -1 on error. Call `turbolite_last_error()` for details.
+ */
+int turbolite_register_local_file_first(const char *name,
+                                        const char *database_path,
+                                        int compression_level);
+#endif
+
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
+/**
+ * Register a local TurboliteVfs (lower-level: caller picks cache_dir).
+ *
+ * Lower-level than [`turbolite_register_local_file_first`]: turbolite owns
+ * the entire `cache_dir` directory and stores the local database image at
+ * `<cache_dir>/data.cache` instead of a caller-supplied file path. Use this
+ * only when you need to control the cache layout directly. New embedders
+ * should prefer the file-first registration so the user-facing artifact is
+ * `app.db`, not `cache_dir/data.cache`.
+ *
+ * # Parameters
+ * - `name`: VFS name (e.g. `"turbolite"`). Must be unique per process.
+ * - `cache_dir`: Directory turbolite owns for its page-group storage.
  * - `compression_level`: zstd level 1-22 (3 is a good default).
  *
  * # Returns
  * 0 on success, -1 on error. Call `turbolite_last_error()` for details.
  */
 int turbolite_register_local(const char *name, const char *cache_dir, int compression_level);
+#endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
+/**
+ * Compute the hidden sidecar directory path for a database file.
+ *
+ * Convenience for bindings that want to assert or eagerly create the
+ * sidecar location without re-implementing the suffix rule. For
+ * `database_path = "/data/app.db"` the result is `/data/app.db-turbolite`.
+ *
+ * The returned string is heap-allocated; callers must free it with
+ * [`turbolite_free_string`].
+ *
+ * Returns NULL if `database_path` is NULL or not valid UTF-8.
+ */
+char *turbolite_state_dir_for_database_path(const char *database_path);
+#endif
+
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Register a TurboliteVfs from a JSON configuration string.
  *
  * Unified entry point that supports both local and cloud modes. The JSON
  * object is deserialized into a `TurboliteConfig`. Unknown fields are ignored.
  *
- * # Minimal JSON (local mode)
+ * # File-first local mode (recommended)
+ *
+ * ```json
+ * { "local_data_path": "/data/app.db" }
+ * ```
+ *
+ * turbolite owns `app.db` as the local page image; sidecar metadata lives
+ * next to it under `app.db-turbolite/`. The optional `cache_dir` field
+ * overrides the derived sidecar location.
+ *
+ * # Lower-level local mode
  *
  * ```json
  * { "cache_dir": "/data/mydb" }
  * ```
+ *
+ * turbolite owns the directory and stores the page image at
+ * `/data/mydb/data.cache`. Prefer the file-first form for new embedders.
  *
  * # Cloud mode
  *
  * ```json
  * {
  *   "storage_backend": { "S3": { "bucket": "my-bucket", "prefix": "db/" } },
- *   "cache_dir": "/tmp/cache"
+ *   "local_data_path": "/data/app.db"
  * }
  * ```
  *
@@ -84,8 +161,9 @@ int turbolite_register_local(const char *name, const char *cache_dir, int compre
  * 0 on success, -1 on error. Call `turbolite_last_error()` for details.
  */
 int turbolite_register(const char *name, const char *config_json);
+#endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (!defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Register an S3-backed cloud VFS.
  *
@@ -111,7 +189,7 @@ int turbolite_register_cloud(const char *name,
                              const char *region);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (!defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Backward-compatible alias for `turbolite_register_cloud`.
  */
@@ -123,13 +201,16 @@ int turbolite_register_tiered(const char *name,
                               const char *region);
 #endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Clear all VFS caches (shared file state, in-process locks).
  *
  * Call this when running fresh benchmarks or tests to ensure no stale state.
  */
 void turbolite_clear_caches(void);
+#endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Invalidate cached state for a specific database file.
  *
@@ -139,7 +220,9 @@ void turbolite_clear_caches(void);
  * 0 on success, -1 on error.
  */
 int turbolite_invalidate_cache(const char *path);
+#endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Open a database using a previously registered VFS.
  *
@@ -151,7 +234,9 @@ int turbolite_invalidate_cache(const char *path);
  * Opaque handle on success, NULL on error. Must be closed with `turbolite_close`.
  */
 struct TurboliteDb *turbolite_open(const char *path, const char *vfs_name);
+#endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Execute a SQL statement (DDL/DML) that returns no rows.
  *
@@ -159,7 +244,9 @@ struct TurboliteDb *turbolite_open(const char *path, const char *vfs_name);
  * 0 on success, -1 on error.
  */
 int turbolite_exec(struct TurboliteDb *db, const char *sql);
+#endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Execute a SQL query and return results as a JSON array of objects.
  *
@@ -170,17 +257,23 @@ int turbolite_exec(struct TurboliteDb *db, const char *sql);
  * or NULL on error.
  */
 char *turbolite_query_json(struct TurboliteDb *db, const char *sql);
+#endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Free a string returned by `turbolite_query_json`.
  */
 void turbolite_free_string(char *s);
+#endif
 
+#if !defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Close a database connection opened with `turbolite_open`.
  */
 void turbolite_close(struct TurboliteDb *db);
+#endif
 
+#if defined(TURBOLITE_LOADABLE_EXTENSION)
 /**
  * Called from C entry point (`sqlite3_turbolite_init` in ext_entry.c).
  * Returns 0 on success, 1 on error. Idempotent: second call is a no-op.
@@ -190,8 +283,9 @@ void turbolite_close(struct TurboliteDb *db);
  * Panics if TURBOLITE_BUCKET is set but tiered VFS creation fails.
  */
 int turbolite_ext_register_vfs(void);
+#endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Clear cache. mode: 0 = all, 1 = data only, 2 = interior only (keeps interior + group 0).
  * Returns 0 on success, 1 if no tiered VFS.
@@ -199,28 +293,47 @@ int turbolite_ext_register_vfs(void);
 int32_t turbolite_bench_clear_cache(int32_t mode);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
+int32_t turbolite_bench_flush_to_storage(void);
+#endif
+
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
- * Reset S3 counters. Returns 0 on success.
+ * Reset S3 counters. Always returns 0; counters are now backend-impl
+ * specific and not exposed through the generic trait.
  */
 int32_t turbolite_bench_reset_s3(void);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
- * Get S3 GET count since last reset.
+ * Get S3 GET count. Returns 0: not surfaced through the generic
+ * `StorageBackend` trait. Embedders that need per-backend metrics
+ * hold a concrete `hadb_storage_s3::S3Storage` directly.
  */
 int64_t turbolite_bench_s3_gets(void);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
- * Get S3 GET bytes since last reset.
+ * Get S3 GET bytes. Always 0; see above.
  */
 int64_t turbolite_bench_s3_bytes(void);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
+int64_t turbolite_bench_s3_puts(void);
+#endif
+
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
+int64_t turbolite_bench_s3_put_bytes(void);
+#endif
+
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && !defined(TURBOLITE_CLOUD))
+int32_t turbolite_bench_flush_to_storage(void);
+#endif
+
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Evict cached data for named trees. tree_names is a comma-separated C string.
  * Returns number of groups evicted, or -1 if no tiered VFS.
@@ -228,11 +341,11 @@ int64_t turbolite_bench_s3_bytes(void);
 int32_t turbolite_evict_tree(const char *tree_names);
 #endif
 
-#if !defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && !defined(TURBOLITE_CLOUD))
 int32_t turbolite_evict_tree(const char *_tree_names);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Return cache info as a JSON C string. Caller must treat as SQLITE_TRANSIENT.
  * Returns null if no tiered VFS.
@@ -242,7 +355,7 @@ int32_t turbolite_evict_tree(const char *_tree_names);
 const char *turbolite_cache_info(void);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Warm cache for a planned query. Runs EQP to extract trees, submits groups to prefetch.
  * Returns JSON C string with trees warmed and groups submitted. Null if no tiered VFS.
@@ -251,11 +364,11 @@ const char *turbolite_cache_info(void);
 const char *turbolite_warm(void *db, const char *sql);
 #endif
 
-#if !defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && !defined(TURBOLITE_CLOUD))
 const char *turbolite_warm(void *_db, const char *_sql);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Evict cached data for trees referenced by a SQL query. Runs EQP, extracts
  * tree names, evicts their groups. Returns groups evicted, or -1 if no VFS.
@@ -263,11 +376,11 @@ const char *turbolite_warm(void *_db, const char *_sql);
 int32_t turbolite_evict_query(void *db, const char *sql);
 #endif
 
-#if !defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && !defined(TURBOLITE_CLOUD))
 int32_t turbolite_evict_query(void *_db, const char *_sql);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Evict cached sub-chunks by tier. Accepts "data", "index", or "all".
  * Returns number of sub-chunks evicted, or -1 if no tiered VFS.
@@ -275,15 +388,15 @@ int32_t turbolite_evict_query(void *_db, const char *_sql);
 int32_t turbolite_evict(const char *tier);
 #endif
 
-#if !defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && !defined(TURBOLITE_CLOUD))
 int32_t turbolite_evict(const char *_tier);
 #endif
 
-#if !defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && !defined(TURBOLITE_CLOUD))
 const char *turbolite_cache_info(void);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Full GC: list all S3 objects under prefix, delete orphans not in manifest.
  * Returns number of objects deleted, or -1 if no tiered VFS.
@@ -291,7 +404,7 @@ const char *turbolite_cache_info(void);
 int32_t turbolite_gc(void);
 #endif
 
-#if defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && defined(TURBOLITE_CLOUD))
 /**
  * Compact B-tree groups: re-walk B-trees, repack groups with >30% dead space.
  * Returns JSON report string (caller must free), or null on error.
@@ -299,31 +412,55 @@ int32_t turbolite_gc(void);
 const char *turbolite_compact(void);
 #endif
 
-#if !defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && !defined(TURBOLITE_CLOUD))
 const char *turbolite_compact(void);
 #endif
 
-#if !defined(TURBOLITE_CLOUD)
+#if (defined(TURBOLITE_LOADABLE_EXTENSION) && !defined(TURBOLITE_CLOUD))
 int32_t turbolite_gc(void);
 #endif
 
-extern int32_t sqlite3_prepare_v2(void *db,
-                                  const char *sql,
-                                  int32_t nbyte,
-                                  void **stmt,
-                                  const char **tail);
+#if defined(TURBOLITE_LOADABLE_EXTENSION)
+/**
+ * Create and register a new local VFS with a custom name and cache directory.
+ * Called from SQL: SELECT turbolite_register_vfs('name', '/path/to/cache_dir').
+ * Each registered VFS gets its own manifest, cache, and page group state,
+ * enabling multiple independent databases in the same process.
+ *
+ * This is the lower-level form: turbolite owns the entire `cache_dir` and
+ * stores the local database image at `<cache_dir>/data.cache`. Bindings that
+ * expose a user-facing `app.db` should prefer
+ * [`turbolite_ext_register_file_first_vfs`] so the user's database path is
+ * the local image.
+ *
+ * Returns 0 on success, 1 on error.
+ */
+int turbolite_ext_register_named_vfs(const char *name_ptr, const char *cache_dir_ptr);
+#endif
 
-extern int32_t sqlite3_step(void *stmt);
-
-extern const char *sqlite3_column_text(void *stmt, int32_t col);
-
-extern int32_t sqlite3_finalize(void *stmt);
-
-extern int64_t sqlite3_column_int64(void *stmt, int32_t col);
+#if defined(TURBOLITE_LOADABLE_EXTENSION)
+/**
+ * Register a file-first local VFS keyed to a database path.
+ *
+ * Called from SQL via:
+ *
+ * ```sql
+ * SELECT turbolite_register_file_first_vfs('app', '/data/app.db');
+ * ```
+ *
+ * The caller's `db_path` becomes the local database image and turbolite
+ * stores its sidecar metadata at `<db_path>-turbolite/`. This is the
+ * recommended user-facing entry point — bindings should expose this rather
+ * than the bare `cache_dir`-driven [`turbolite_ext_register_named_vfs`].
+ *
+ * Returns 0 on success, 1 on error.
+ */
+int turbolite_ext_register_file_first_vfs(const char *name_ptr, const char *db_path_ptr);
+#endif
 
 /**
- * FFI entry point called from C trace callback.
- * Runs EQP, parses, and pushes to global queue.
+ * Run EQP on `sql` against `db` and push the planned accesses onto the
+ * global plan queue. Invoked from `SQLITE_TRACE_STMT`.
  *
  * # Safety
  * `db` must be a valid sqlite3 handle. `sql` must be a valid C string.
@@ -331,18 +468,123 @@ extern int64_t sqlite3_column_int64(void *stmt, int32_t col);
 void turbolite_trace_push_plan(void *db, const char *sql);
 
 /**
- * FFI entry point called from C trace profile callback.
- * Signals query completion for between-query eviction.
+ * Signal query completion so the VFS runs between-query eviction on the
+ * next read. Invoked from `SQLITE_TRACE_PROFILE`.
  */
 void turbolite_trace_end_query(void);
 
 /**
- * FFI entry point: `turbolite_config_set(key, value)` SQL function.
+ * FFI entry point: `turbolite_config_set(key, value)`.
+ *
+ * Returns:
+ *   0 — pushed successfully
+ *   1 — validation failed (unknown key or bad value)
+ *   2 — no active turbolite handle on this thread
  *
  * # Safety
  * `key` and `value` must be valid C strings.
  */
-int32_t turbolite_config_set(const char *key, const char *value);
+int turbolite_config_set(const char *key, const char *value);
+
+/**
+ * Clone an Arc to the current thread's top-of-stack handle queue, or
+ * return NULL if no turbolite connection is active on this thread.
+ *
+ * The returned pointer owns one refcount; the caller must eventually
+ * release it via [`turbolite_settings_queue_free`] — typically by
+ * handing it to `sqlite3_create_function_v2` as `pApp` with
+ * [`turbolite_settings_queue_free_cb`] as `xDestroy`.
+ *
+ * Used by `turbolite_install_config_functions` to snapshot the calling
+ * connection's queue at install time.
+ */
+const void *turbolite_current_queue_clone(void);
+
+/**
+ * Drop one refcount on a queue pointer previously returned by
+ * [`turbolite_current_queue_clone`]. NULL is a no-op.
+ *
+ * # Safety
+ * `ptr` must be NULL or a pointer returned by
+ * `turbolite_current_queue_clone` (not yet freed).
+ */
+void turbolite_settings_queue_free(const void *ptr);
+
+/**
+ * `xDestroy` callback signature wrapper for
+ * `sqlite3_create_function_v2`. `void *` instead of `const void *` to
+ * match SQLite's callback ABI.
+ *
+ * # Safety
+ * `ptr` must be NULL or a pointer returned by
+ * `turbolite_current_queue_clone` (not yet freed).
+ */
+void turbolite_settings_queue_free_cb(void *ptr);
+
+/**
+ * Push a `(key, value)` update into a specific queue pointer. Used by
+ * the C shim's `turbolite_config_set_func` after pApp-capture.
+ *
+ * Returns:
+ *   0 — pushed successfully
+ *   1 — validation failed (unknown key / bad value) or null pointer
+ *
+ * # Safety
+ * `queue_ptr` must be a live pointer returned by
+ * `turbolite_current_queue_clone`. `key` / `value` must be valid C
+ * strings.
+ */
+int turbolite_settings_queue_push(const void *queue_ptr, const char *key, const char *value);
+
+extern int sqlite3_exec(sqlite3 *db,
+                        const char *sql,
+                        const void *callback,
+                        const void *arg,
+                        char **errmsg);
+
+extern void sqlite3_free(void *ptr);
+
+extern int sqlite3_create_function_v2(sqlite3 *db,
+                                      const char *zFunctionName,
+                                      int nArg,
+                                      int eTextRep,
+                                      void *pApp,
+                                      struct Option_CreateFnStep xFunc,
+                                      struct Option_CreateFnStep xStep,
+                                      struct Option_CreateFnFinal xFinal,
+                                      struct Option_CreateFnDestroy xDestroy);
+
+extern void *sqlite3_user_data(sqlite3_context *ctx);
+
+extern const char *sqlite3_value_text(sqlite3_value *value);
+
+extern void sqlite3_result_error(sqlite3_context *ctx, const char *msg, int len);
+
+extern void sqlite3_result_int(sqlite3_context *ctx, int val);
+
+extern int sqlite3_file_control(sqlite3 *db, const char *zDbName, int op, void *arg);
+
+/**
+ * Register the `turbolite_config_set(key, value)` SQL function on this
+ * connection, capturing the calling connection's handle queue via
+ * `sqlite3_create_function_v2`'s `pApp`.
+ *
+ * Returns:
+ * - `SQLITE_OK` (0) on success
+ * - `SQLITE_MISUSE` if the connection's VFS isn't one of turbolite's
+ *   registered names (protects against cross-connection queue leaks
+ *   when this function is called on a non-turbolite connection while
+ *   a turbolite handle is alive on the same thread — the queue would
+ *   otherwise route pushes to the wrong connection)
+ * - A SQLite error code if the `PRAGMA schema_version` probe fails
+ *   (connection isn't turbolite-backed)
+ * - `SQLITE_MISUSE` if no turbolite handle is active on this thread
+ *   after the probe
+ *
+ * # Safety
+ * `db` must be a live `sqlite3*` handle.
+ */
+int turbolite_install_config_functions(sqlite3 *db);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/turbolite.h
+++ b/turbolite.h
@@ -131,9 +131,10 @@ char *turbolite_state_dir_for_database_path(const char *database_path);
  * { "local_data_path": "/data/app.db" }
  * ```
  *
- * turbolite owns `app.db` as the local page image; sidecar metadata lives
- * next to it under `app.db-turbolite/`. The optional `cache_dir` field
- * overrides the derived sidecar location.
+ * turbolite owns `app.db` as the local page image; the sidecar lives next
+ * to it under `app.db-turbolite/`. When `local_data_path` is set and
+ * `cache_dir` is *not* supplied, the sidecar path is derived from
+ * `local_data_path`. To pin the sidecar somewhere else, set both fields.
  *
  * # Lower-level local mode
  *
@@ -271,6 +272,14 @@ void turbolite_free_string(char *s);
  * Close a database connection opened with `turbolite_open`.
  */
 void turbolite_close(struct TurboliteDb *db);
+#endif
+
+#if defined(TURBOLITE_LOADABLE_EXTENSION)
+extern int turbolite_sqlite3_turbolite_init_impl(void *db, char **pz_err_msg, const void *p_api);
+#endif
+
+#if defined(TURBOLITE_LOADABLE_EXTENSION)
+int sqlite3_turbolite_init(void *db, char **pz_err_msg, const void *p_api);
 #endif
 
 #if defined(TURBOLITE_LOADABLE_EXTENSION)
@@ -452,6 +461,10 @@ int turbolite_ext_register_named_vfs(const char *name_ptr, const char *cache_dir
  * stores its sidecar metadata at `<db_path>-turbolite/`. This is the
  * recommended user-facing entry point — bindings should expose this rather
  * than the bare `cache_dir`-driven [`turbolite_ext_register_named_vfs`].
+ *
+ * Other `TURBOLITE_*` env vars (compression, cache, prefetch, read-only)
+ * are honored via `TurboliteConfig::from_env()`; only the cache_dir is
+ * overridden to match the database path.
  *
  * Returns 0 on success, 1 on error.
  */


### PR DESCRIPTION
Re-files PR #28 against `main` now that PR #27 (file-first substrate) has merged. Same scope, rebased onto main with the loadable-extension entry-point rename (`turbolite_c_sqlite3_turbolite_init`) reconciled.

## Summary

Two things in one PR (both came out of the same audit pass):

1. **File-first bindings**: thread the file-first substrate primitives from PR #27 through every maintained binding, so the user-facing artifact is `app.db` (not `cache_dir/data.cache`).
2. **Substrate fix**: replace a `lock-downgrade-without-sync` rollback heuristic that was silently dropping every write under `PRAGMA synchronous=OFF`.

## File-first bindings

### turbolite-ffi (C ABI)
- New `turbolite_register_local_file_first(name, database_path, level)`.
- New `turbolite_state_dir_for_database_path(path)` helper.
- JSON `turbolite_register` now derives the sidecar from `local_data_path` when `cache_dir` is not explicitly supplied.
- `turbolite_register_local(name, cache_dir, level)` kept as lower-level.

### Loadable extension
- New SQL function `turbolite_register_file_first_vfs(name, db_path)`.
- Default `"turbolite"` VFS honors `TURBOLITE_DATABASE_PATH` (same env path applies to `"turbolite-s3"`).
- All file-first paths start from `TurboliteConfig::from_env().with_database_path(...)`, so other `TURBOLITE_*` env knobs (read-only, compression, prefetch) are honored consistently.

### Bindings
- **Python** (`turbolite-ffi/packages/python` + legacy `packages/python`): `turbolite.connect(path)` registers a per-db file-first VFS via the new SQL function. New `state_dir_for_database_path(path)` helper. Missing parent dir surfaces as `FileNotFoundError`.
- **Node** (`turbolite-ffi/packages/node` + legacy `packages/node`): `connect(dbPath)` calls `turbolite_register_file_first_vfs(name, dbPath)`. New `stateDirForDatabasePath(path)` export.
- **Go** (`turbolite-ffi/packages/go`): `Open(path, opts)` switches to `turbolite_register_file_first_vfs(name, absPath)`. New `StateDirForDatabasePath(path)` helper.

### Examples
- `examples/{c,go,node,python}/local.*` lead with file-first.
- C example calls `turbolite_register_local_file_first`.
- Node example fixed: was using a non-existent `Database` export and `db.query` API; now uses `connect()` with prepared statements (also removes the SQL-injection-prone string concatenation).

### Docs
- README + binding READMEs lead with `app.db` / `app.db-turbolite/`.
- Document that `app.db` is turbolite's compressed page image, not promised to be opened by stock `sqlite3`.
- Document export paths: Python `iterdump`, Node `db.backup`, Rust/FFI online backup API.

## Substrate fix: lock-downgrade-without-sync rollback heuristic

`TurboliteHandle::lock` (`src/tiered/handle.rs`) had a heuristic that, when SQLite downgraded the lock from EXCLUSIVE/RESERVED to SHARED/NONE *without* having called xSync, treated the situation as a rollback and discarded every dirty page. Assumption: commits always call xSync; only rollbacks leave dirty pages unsynced.

That assumption is wrong under `PRAGMA synchronous=OFF`. SQLite skips xSync on *every* commit in OFF mode, so the heuristic fired on every commit and silently dropped the writes — even after a clean `turbolite_close` and an explicit `wal_checkpoint(TRUNCATE)`. Pages were sitting in `data.cache` but the manifest never recorded them, so the next reopen reported `page_count=0` and read zero-fill.

`sync=OFF` doesn't make architectural sense for turbolite in the first place — turbolite's durability is gated by manifest+bitmap+staging-log persistence inside `sync()`, not by SQLite's fsync calls. So `sync=OFF` doesn't buy any speedup; it only weakens the contract.

**Fix**: replace the heuristic with an unconditional `sync()` at lock downgrade. Correct for all three cases:
- WAL commit: checkpoint writes new pages → `sync()` persists.
- Rollback-journal commit: xWrite then `sync()`.
- Rollback: SQLite replays the journal back to the main DB via xWrite before releasing the lock, so dirty pages hold the rolled-back original bytes — `sync()` persists those (correctly).

## What stayed lower-level (intentional)

- `turbolite_register_local(name, cache_dir, level)` (C ABI)
- `turbolite_register_vfs(name, cache_dir)` (SQL function)
- `TURBOLITE_CACHE_DIR` env var
- The `cache_dir` field on `TurboliteConfig` and the JSON config

## Test coverage (positive + negative per piece)

| Piece                                           | Positive | Negative |
|-------------------------------------------------|----------|----------|
| `turbolite_register_local_file_first`           | layout, CRUD, reopen, compression level | NULL name, NULL db_path, alias-open rejection |
| `turbolite_state_dir_for_database_path`         | result correctness | NULL → NULL |
| `turbolite_register` JSON file-first            | derive + explicit override | invalid JSON |
| `turbolite_register_file_first_vfs` SQL fn      | full e2e | NULL args |
| `TURBOLITE_DATABASE_PATH` env var               | layout produced | other env knobs preserved |
| Python `connect(path)` file-first               | layout, relative path, two-DB isolation, iterdump export | parent dir missing, S3 no bucket |
| Node `connect(dbPath)` file-first               | layout | parent dir missing, S3 no bucket |
| Go `Open(path)` file-first                      | layout | parent dir, no bucket, invalid SQL |
| C FFI test                                      | full file-first round-trip | NULL args |
| **Substrate: persistence under any sync mode**  | matrix of 11 (journal, sync) pairs | rollback under sync=OFF preserves pre-txn state |
| **Substrate: multiple commits under sync=OFF**  | 10 separate BEGIN/COMMIT cycles all persist | n/a |

## Validation (post-rebase onto main)

- `cargo test -p turbolite --lib` -> 526 passed
- `cargo test -p turbolite-ffi --features zstd,bundled-sqlite --tests --no-fail-fast`
  - `ffi_test`: 49 passed
  - `ffi_safety`: 46 passed
  - `install_config_functions`: 5 passed
  - **`crash_recovery`: 19 passed** (was 15/16 before the substrate fix)
- Python binding: 7 passed (S3 skipped)
- Node binding: 29 passed (S3 skipped)
- Go binding: all passed
- C FFI: 11 passed
- Loadable extension Python: 27 passed

## Replaces

This re-files PR #28 (`closed`) against `main` after PR #27 (`codex/matryoshka-checkpoint-delta-contract`) merged. Identical scope, rebased onto current main with the loadable-extension entry-point rename (`turbolite_c_sqlite3_turbolite_init`) reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)