### PR TITLE
Make S3 VFS identity per volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ conn = sqlite3.connect(":memory:")
 turbolite.load(conn)
 conn.close()
 conn = sqlite3.connect("file:my.db?vfs=turbolite", uri=True)       # local
-conn = sqlite3.connect("file:my.db?vfs=turbolite-s3", uri=True)    # S3 (needs TURBOLITE_BUCKET)
+# For S3, prefer turbolite.connect(..., mode="s3", bucket=..., prefix=...).
+# It registers a per-database VFS so multiple S3 volumes can share one process.
 ```
 
 **Node.js**: `npm install turbolite` — see [turbolite-ffi/packages/node/](turbolite-ffi/packages/node/)
@@ -442,7 +443,7 @@ make ext  # produces target/release/turbolite.{so,dylib}
 sqlite3_enable_load_extension(db, 1);
 sqlite3_load_extension(db, "path/to/turbolite", NULL, NULL);
 // "turbolite" VFS (local) is always registered
-// "turbolite-s3" VFS is also registered if TURBOLITE_BUCKET is set
+// "turbolite-s3" is a single-volume convenience VFS when TURBOLITE_BUCKET is set
 ```
 
 For the file-first user story, register a per-database VFS that owns the

--- a/packages/python/test_turbolite.py
+++ b/packages/python/test_turbolite.py
@@ -229,6 +229,97 @@ def test_s3_write_read():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_s3_two_prefixes_same_process_do_not_cross():
+    """S3 mode: two prefixes in one process must get distinct VFS identities."""
+    bucket = os.environ.get("TIERED_TEST_BUCKET") or os.environ.get("TURBOLITE_BUCKET")
+    if not bucket:
+        print("SKIP: S3 tests (no TIERED_TEST_BUCKET set)")
+        return
+
+    print("test: S3 two-prefix isolation in one process...")
+    d = tempfile.mkdtemp()
+    try:
+        prefix_base = f"test/python-isolation-{os.getpid()}"
+        conn_a = turbolite.connect(
+            os.path.join(d, "a.db"),
+            mode="s3",
+            bucket=bucket,
+            prefix=f"{prefix_base}/a",
+            endpoint=os.environ.get("AWS_ENDPOINT_URL"),
+            region="auto",
+            cache_dir=os.path.join(d, "a-cache"),
+        )
+        conn_b = turbolite.connect(
+            os.path.join(d, "b.db"),
+            mode="s3",
+            bucket=bucket,
+            prefix=f"{prefix_base}/b",
+            endpoint=os.environ.get("AWS_ENDPOINT_URL"),
+            region="auto",
+            cache_dir=os.path.join(d, "b-cache"),
+        )
+
+        conn_a.execute("CREATE TABLE marker (value TEXT)")
+        conn_a.execute("INSERT INTO marker VALUES ('from-a')")
+        conn_a.commit()
+        conn_b.execute("CREATE TABLE marker (value TEXT)")
+        conn_b.execute("INSERT INTO marker VALUES ('from-b')")
+        conn_b.commit()
+
+        assert conn_a.execute("SELECT value FROM marker").fetchone()[0] == "from-a"
+        assert conn_b.execute("SELECT value FROM marker").fetchone()[0] == "from-b"
+
+        conn_a.close()
+        conn_b.close()
+        print("  PASS")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_s3_default_prefixes_do_not_cross():
+    """S3 mode: two paths with default prefixes must not share remote state."""
+    bucket = os.environ.get("TIERED_TEST_BUCKET") or os.environ.get("TURBOLITE_BUCKET")
+    if not bucket:
+        print("SKIP: S3 tests (no TIERED_TEST_BUCKET set)")
+        return
+
+    print("test: S3 default-prefix isolation in one process...")
+    d = tempfile.mkdtemp()
+    try:
+        conn_a = turbolite.connect(
+            os.path.join(d, "default-a.db"),
+            mode="s3",
+            bucket=bucket,
+            endpoint=os.environ.get("AWS_ENDPOINT_URL"),
+            region="auto",
+            cache_dir=os.path.join(d, "default-a-cache"),
+        )
+        conn_b = turbolite.connect(
+            os.path.join(d, "default-b.db"),
+            mode="s3",
+            bucket=bucket,
+            endpoint=os.environ.get("AWS_ENDPOINT_URL"),
+            region="auto",
+            cache_dir=os.path.join(d, "default-b-cache"),
+        )
+
+        conn_a.execute("CREATE TABLE marker (value TEXT)")
+        conn_a.execute("INSERT INTO marker VALUES ('default-a')")
+        conn_a.commit()
+        conn_b.execute("CREATE TABLE marker (value TEXT)")
+        conn_b.execute("INSERT INTO marker VALUES ('default-b')")
+        conn_b.commit()
+
+        assert conn_a.execute("SELECT value FROM marker").fetchone()[0] == "default-a"
+        assert conn_b.execute("SELECT value FROM marker").fetchone()[0] == "default-b"
+
+        conn_a.close()
+        conn_b.close()
+        print("  PASS")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def test_s3_requires_bucket():
     """S3 mode without bucket should raise ValueError."""
     print("test: S3 mode requires bucket...")
@@ -246,10 +337,11 @@ def test_s3_requires_bucket():
 
 
 if __name__ == "__main__":
-    # S3 write test must run FIRST: the extension init only runs once per
-    # process, and TURBOLITE_BUCKET must be set before loading to register
-    # turbolite-s3. Local mode works regardless of load order.
+    # S3 tests can run before or after local tests: S3 mode now registers
+    # a per-volume VFS instead of relying on process-global turbolite-s3.
     test_s3_write_read()
+    test_s3_two_prefixes_same_process_do_not_cross()
+    test_s3_default_prefixes_do_not_cross()
     test_local_basic_crud()
     test_local_file_first_layout()
     test_local_relative_path()

--- a/packages/python/turbolite/__init__.py
+++ b/packages/python/turbolite/__init__.py
@@ -25,6 +25,7 @@ rejects the alias open of a different target file by design.
 from __future__ import annotations
 
 import itertools
+import hashlib
 import os
 import platform
 import sqlite3
@@ -37,6 +38,7 @@ __version__ = "0.4.1"
 # Each connect() call gets its own VFS so manifest/cache/sidecar state stays
 # pinned to one database file.
 _vfs_counter = itertools.count()
+_s3_vfs_by_fingerprint: dict[tuple[object, ...], str] = {}
 
 
 def _find_ext() -> str:
@@ -70,8 +72,8 @@ def load(conn: sqlite3.Connection) -> None:
     Load the turbolite extension into a sqlite3 connection.
 
     After loading, the "turbolite" VFS (local mode) is always registered.
-    If TURBOLITE_BUCKET is set in the environment, "turbolite-s3"
-    (S3 cloud mode) is also registered.
+    S3 connections register a per-volume VFS from explicit connect()
+    arguments; they do not rely on the process-global "turbolite-s3" VFS.
 
     Args:
         conn: Any open sqlite3.Connection (can be :memory:).
@@ -109,6 +111,45 @@ def state_dir_for_database_path(path: str) -> str:
     return f"{os.fspath(path)}-turbolite"
 
 
+def _s3_fingerprint(
+    *,
+    abs_path: str,
+    bucket: str,
+    prefix: str,
+    endpoint: str | None,
+    region: str | None,
+    cache_dir: str | None,
+    compression_level: int | None,
+    prefetch_threads: int | None,
+    read_only: bool,
+    page_cache: str,
+) -> tuple[object, ...]:
+    return (
+        abs_path,
+        bucket,
+        prefix,
+        endpoint or "",
+        region or "",
+        cache_dir or "",
+        compression_level or "",
+        prefetch_threads or "",
+        read_only,
+        page_cache,
+    )
+
+
+def _default_s3_vfs_name(fingerprint: tuple[object, ...]) -> str:
+    material = "\0".join(str(part) for part in fingerprint)
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"turbolite-s3-{digest}"
+
+
+def _default_s3_prefix(abs_path: str) -> str:
+    stem = os.path.basename(abs_path).replace("/", "_") or "database"
+    digest = hashlib.sha256(abs_path.encode("utf-8")).hexdigest()[:16]
+    return f"turbolite/{stem}-{digest}"
+
+
 def connect(
     path: str,
     *,
@@ -134,7 +175,8 @@ def connect(
         path: Path to the database file. May be relative or absolute.
         mode: "local" for local VFS, "s3" for S3 cloud VFS.
         bucket: S3 bucket (required for mode="s3", or set TURBOLITE_BUCKET).
-        prefix: S3 key prefix (default "turbolite").
+        prefix: S3 key prefix. Defaults to a stable prefix derived from the
+            database path, so distinct paths do not overlap in one bucket.
         endpoint: S3 endpoint URL (Tigris, MinIO). Falls back to AWS_ENDPOINT_URL.
         region: AWS region. Falls back to AWS_REGION.
         cache_dir: Lower-level override for the sidecar directory. When unset
@@ -163,21 +205,11 @@ def connect(
         )
 
     if mode == "s3":
-        # Set env vars BEFORE loading the extension. The C init function
-        # checks TURBOLITE_BUCKET to decide whether to register turbolite-s3.
-        # Once loaded, the VFS is registered for the process lifetime.
         effective_bucket = bucket or os.environ.get("TURBOLITE_BUCKET")
         if not effective_bucket:
             raise ValueError(
                 "mode='s3' requires a bucket. Pass bucket= or set TURBOLITE_BUCKET."
             )
-        os.environ["TURBOLITE_BUCKET"] = effective_bucket
-        if prefix is not None:
-            os.environ["TURBOLITE_PREFIX"] = prefix
-        if endpoint is not None:
-            os.environ["TURBOLITE_ENDPOINT_URL"] = endpoint
-        if region is not None:
-            os.environ["TURBOLITE_REGION"] = region
         if cache_dir is not None:
             os.environ["TURBOLITE_CACHE_DIR"] = cache_dir
         if read_only:
@@ -189,15 +221,9 @@ def connect(
         os.environ["TURBOLITE_PREFETCH_THREADS"] = str(prefetch_threads)
     os.environ["TURBOLITE_MEM_CACHE_BUDGET"] = page_cache
 
-    # Load the extension once. S3 env vars must be set BEFORE first load
-    # because the C init function only runs once per process.
-    if mode == "s3" and _loaded_local and not _loaded_s3:
-        raise RuntimeError(
-            "Cannot switch to S3 mode after local mode was already loaded. "
-            "The SQLite extension init only runs once per process. "
-            "Use mode='s3' on the first turbolite.connect() call, or set "
-            "TURBOLITE_BUCKET in the environment before importing turbolite."
-        )
+    # Load the extension once. S3 mode no longer depends on a fixed
+    # process-global VFS registered at extension load time; each S3 connect
+    # registers a per-volume VFS below.
     boot = _ensure_bootstrap()
 
     if mode == "local":
@@ -214,13 +240,48 @@ def connect(
                 f"turbolite: failed to register file-first VFS '{vfs}' for {abs_path}"
             )
     else:
-        if not _loaded_s3:
+        effective_bucket = bucket or os.environ.get("TURBOLITE_BUCKET")
+        if not effective_bucket:
             raise RuntimeError(
-                "Cannot use S3 mode: TURBOLITE_BUCKET was not set when the extension "
-                "was first loaded. Set TURBOLITE_BUCKET in the environment before "
-                "the first turbolite.connect() call."
+                "Cannot use S3 mode: pass bucket= or set TURBOLITE_BUCKET."
             )
-        vfs = "turbolite-s3"
+        effective_prefix = (
+            prefix or os.environ.get("TURBOLITE_PREFIX") or _default_s3_prefix(abs_path)
+        )
+        effective_endpoint = endpoint or os.environ.get("TURBOLITE_ENDPOINT_URL") or os.environ.get("AWS_ENDPOINT_URL")
+        effective_region = region or os.environ.get("TURBOLITE_REGION") or os.environ.get("AWS_REGION")
+        fingerprint = _s3_fingerprint(
+            abs_path=abs_path,
+            bucket=effective_bucket,
+            prefix=effective_prefix,
+            endpoint=effective_endpoint,
+            region=effective_region,
+            cache_dir=cache_dir,
+            compression_level=compression_level,
+            prefetch_threads=prefetch_threads,
+            read_only=read_only,
+            page_cache=page_cache,
+        )
+        vfs = _s3_vfs_by_fingerprint.get(fingerprint)
+        if vfs is None:
+            vfs = _default_s3_vfs_name(fingerprint)
+            rc = boot.execute(
+                "SELECT turbolite_register_s3_file_first_vfs(?, ?, ?, ?, ?, ?)",
+                (
+                    vfs,
+                    abs_path,
+                    effective_bucket,
+                    effective_prefix,
+                    effective_endpoint,
+                    effective_region,
+                ),
+            ).fetchone()[0]
+            if rc != 0:
+                raise RuntimeError(
+                    f"turbolite: failed to register file-first S3 VFS '{vfs}' "
+                    f"for {abs_path} at {effective_bucket}/{effective_prefix}"
+                )
+            _s3_vfs_by_fingerprint[fingerprint] = vfs
 
     conn = sqlite3.connect(f"file:{abs_path}?vfs={vfs}", uri=True)
 

--- a/src/tiered/handle.rs
+++ b/src/tiered/handle.rs
@@ -2986,9 +2986,7 @@ impl DatabaseHandle for TurboliteHandle {
             && self.dirty_since_sync
         {
             if let Err(e) = self.sync(false) {
-                eprintln!(
-                    "[turbolite] flush-on-lock-downgrade failed: {e}"
-                );
+                eprintln!("[turbolite] flush-on-lock-downgrade failed: {e}");
             }
         }
 

--- a/turbolite-ffi/packages/go/turbolite.go
+++ b/turbolite-ffi/packages/go/turbolite.go
@@ -29,10 +29,12 @@
 package turbolite
 
 import (
+	"crypto/sha256"
 	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -47,7 +49,7 @@ type Options struct {
 	Bucket string
 	// S3 endpoint URL (for Tigris, MinIO).
 	Endpoint string
-	// S3 key prefix (default "turbolite").
+	// S3 key prefix. Defaults to a stable prefix derived from the database path.
 	Prefix string
 	// AWS region.
 	Region string
@@ -72,10 +74,42 @@ var (
 	bootstrapErr  error
 	bootstrapDB   *sql.DB
 
+	s3RegistryMu sync.Mutex
+	s3VFSByKey   = map[string]string{}
+
 	extPathOnce sync.Once
 	extPath     string
 	extPathErr  error
 )
+
+func defaultS3VFSName(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return fmt.Sprintf("turbolite-s3-%x", sum[:8])
+}
+
+func defaultS3Prefix(absPath string) string {
+	sum := sha256.Sum256([]byte(absPath))
+	stem := filepath.Base(absPath)
+	if stem == "." || stem == string(filepath.Separator) || stem == "" {
+		stem = "database"
+	}
+	return fmt.Sprintf("turbolite/%s-%x", stem, sum[:8])
+}
+
+func s3Fingerprint(absPath, bucket, prefix, endpoint, region, cacheDir, pageCache string, compressionLevel, prefetchThreads int, readOnly bool) string {
+	return strings.Join([]string{
+		absPath,
+		bucket,
+		prefix,
+		endpoint,
+		region,
+		cacheDir,
+		pageCache,
+		fmt.Sprintf("%d", compressionLevel),
+		fmt.Sprintf("%d", prefetchThreads),
+		fmt.Sprintf("%t", readOnly),
+	}, "\x00")
+}
 
 // findExt locates the turbolite loadable extension binary.
 func findExt() (string, error) {
@@ -177,7 +211,9 @@ func Open(path string, opts *Options) (*sql.DB, error) {
 	}
 	dbDir := filepath.Dir(absPath)
 
-	// Set env vars before the extension loads.
+	// Set behavior env vars before VFS registration. S3 bucket/prefix are
+	// passed explicitly to the per-volume registration below; they must not
+	// rely on the process-global "turbolite-s3" shortcut.
 	if opts.Mode == "s3" {
 		bucket := opts.Bucket
 		if bucket == "" {
@@ -185,16 +221,6 @@ func Open(path string, opts *Options) (*sql.DB, error) {
 		}
 		if bucket == "" {
 			return nil, fmt.Errorf("turbolite: mode='s3' requires Bucket or TURBOLITE_BUCKET")
-		}
-		os.Setenv("TURBOLITE_BUCKET", bucket)
-		if opts.Prefix != "" {
-			os.Setenv("TURBOLITE_PREFIX", opts.Prefix)
-		}
-		if opts.Endpoint != "" {
-			os.Setenv("TURBOLITE_ENDPOINT_URL", opts.Endpoint)
-		}
-		if opts.Region != "" {
-			os.Setenv("TURBOLITE_REGION", opts.Region)
 		}
 		if opts.CacheDir != "" {
 			os.Setenv("TURBOLITE_CACHE_DIR", opts.CacheDir)
@@ -233,7 +259,57 @@ func Open(path string, opts *Options) (*sql.DB, error) {
 			return nil, fmt.Errorf("turbolite: register file-first VFS %q: %w", vfsName, err)
 		}
 	} else {
-		vfsName = "turbolite-s3"
+		bucket := opts.Bucket
+		if bucket == "" {
+			bucket = os.Getenv("TURBOLITE_BUCKET")
+		}
+		prefix := opts.Prefix
+		if prefix == "" {
+			prefix = os.Getenv("TURBOLITE_PREFIX")
+		}
+		if prefix == "" {
+			prefix = defaultS3Prefix(absPath)
+		}
+		endpoint := opts.Endpoint
+		if endpoint == "" {
+			endpoint = os.Getenv("TURBOLITE_ENDPOINT_URL")
+			if endpoint == "" {
+				endpoint = os.Getenv("AWS_ENDPOINT_URL")
+			}
+		}
+		region := opts.Region
+		if region == "" {
+			region = os.Getenv("TURBOLITE_REGION")
+			if region == "" {
+				region = os.Getenv("AWS_REGION")
+			}
+		}
+		key := s3Fingerprint(
+			absPath,
+			bucket,
+			prefix,
+			endpoint,
+			region,
+			opts.CacheDir,
+			opts.PageCache,
+			opts.CompressionLevel,
+			opts.PrefetchThreads,
+			opts.ReadOnly,
+		)
+		s3RegistryMu.Lock()
+		vfsName = s3VFSByKey[key]
+		if vfsName == "" {
+			vfsName = defaultS3VFSName(key)
+			_, err := bootstrapDB.Exec(
+				"SELECT turbolite_register_s3_file_first_vfs(?, ?, ?, ?, ?, ?)",
+				vfsName, absPath, bucket, prefix, endpoint, region)
+			if err != nil {
+				s3RegistryMu.Unlock()
+				return nil, fmt.Errorf("turbolite: register file-first S3 VFS %q: %w", vfsName, err)
+			}
+			s3VFSByKey[key] = vfsName
+		}
+		s3RegistryMu.Unlock()
 	}
 
 	// Register a driver that sets per-connection pragmas.

--- a/turbolite-ffi/packages/go/turbolite_test.go
+++ b/turbolite-ffi/packages/go/turbolite_test.go
@@ -740,6 +740,107 @@ func TestS3WriteRead(t *testing.T) {
 	}
 }
 
+func TestS3TwoPrefixesSameProcessDoNotCross(t *testing.T) {
+	bucket := os.Getenv("TIERED_TEST_BUCKET")
+	if bucket == "" {
+		bucket = os.Getenv("TURBOLITE_BUCKET")
+	}
+	if bucket == "" {
+		t.Skip("no TIERED_TEST_BUCKET or TURBOLITE_BUCKET set")
+	}
+
+	dir := tmpDir(t)
+	prefixBase := fmt.Sprintf("test/go-isolation-%d", os.Getpid())
+	dbA, err := Open(filepath.Join(dir, "a.db"), &Options{
+		Mode:     "s3",
+		Bucket:   bucket,
+		Prefix:   prefixBase + "/a",
+		Endpoint: os.Getenv("AWS_ENDPOINT_URL"),
+		Region:   "auto",
+		CacheDir: filepath.Join(dir, "a-cache"),
+	})
+	if err != nil {
+		t.Fatalf("Open S3 A: %v", err)
+	}
+	defer dbA.Close()
+	dbB, err := Open(filepath.Join(dir, "b.db"), &Options{
+		Mode:     "s3",
+		Bucket:   bucket,
+		Prefix:   prefixBase + "/b",
+		Endpoint: os.Getenv("AWS_ENDPOINT_URL"),
+		Region:   "auto",
+		CacheDir: filepath.Join(dir, "b-cache"),
+	})
+	if err != nil {
+		t.Fatalf("Open S3 B: %v", err)
+	}
+	defer dbB.Close()
+
+	dbA.Exec("CREATE TABLE marker (value TEXT)")
+	dbA.Exec("INSERT INTO marker VALUES ('from-a')")
+	dbB.Exec("CREATE TABLE marker (value TEXT)")
+	dbB.Exec("INSERT INTO marker VALUES ('from-b')")
+
+	var a, b string
+	dbA.QueryRow("SELECT value FROM marker").Scan(&a)
+	dbB.QueryRow("SELECT value FROM marker").Scan(&b)
+	if a != "from-a" {
+		t.Fatalf("expected DB A marker from-a, got %q", a)
+	}
+	if b != "from-b" {
+		t.Fatalf("expected DB B marker from-b, got %q", b)
+	}
+}
+
+func TestS3DefaultPrefixesSameProcessDoNotCross(t *testing.T) {
+	bucket := os.Getenv("TIERED_TEST_BUCKET")
+	if bucket == "" {
+		bucket = os.Getenv("TURBOLITE_BUCKET")
+	}
+	if bucket == "" {
+		t.Skip("no TIERED_TEST_BUCKET or TURBOLITE_BUCKET set")
+	}
+
+	dir := tmpDir(t)
+	dbA, err := Open(filepath.Join(dir, "default-a.db"), &Options{
+		Mode:     "s3",
+		Bucket:   bucket,
+		Endpoint: os.Getenv("AWS_ENDPOINT_URL"),
+		Region:   "auto",
+		CacheDir: filepath.Join(dir, "default-a-cache"),
+	})
+	if err != nil {
+		t.Fatalf("Open S3 default A: %v", err)
+	}
+	defer dbA.Close()
+	dbB, err := Open(filepath.Join(dir, "default-b.db"), &Options{
+		Mode:     "s3",
+		Bucket:   bucket,
+		Endpoint: os.Getenv("AWS_ENDPOINT_URL"),
+		Region:   "auto",
+		CacheDir: filepath.Join(dir, "default-b-cache"),
+	})
+	if err != nil {
+		t.Fatalf("Open S3 default B: %v", err)
+	}
+	defer dbB.Close()
+
+	dbA.Exec("CREATE TABLE marker (value TEXT)")
+	dbA.Exec("INSERT INTO marker VALUES ('default-a')")
+	dbB.Exec("CREATE TABLE marker (value TEXT)")
+	dbB.Exec("INSERT INTO marker VALUES ('default-b')")
+
+	var a, b string
+	dbA.QueryRow("SELECT value FROM marker").Scan(&a)
+	dbB.QueryRow("SELECT value FROM marker").Scan(&b)
+	if a != "default-a" {
+		t.Fatalf("expected DB A marker default-a, got %q", a)
+	}
+	if b != "default-b" {
+		t.Fatalf("expected DB B marker default-b, got %q", b)
+	}
+}
+
 func TestS3CacheSizeZero(t *testing.T) {
 	bucket := os.Getenv("TIERED_TEST_BUCKET")
 	if bucket == "" {

--- a/turbolite-ffi/packages/node/src/index.ts
+++ b/turbolite-ffi/packages/node/src/index.ts
@@ -29,6 +29,7 @@
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+import crypto from 'crypto';
 import Database from 'better-sqlite3';
 
 export interface ConnectOptions {
@@ -36,7 +37,7 @@ export interface ConnectOptions {
   mode?: 'local' | 's3';
   /** S3 bucket name (required when mode = "s3"). */
   bucket?: string;
-  /** S3 key prefix (mode = "s3", default "turbolite"). */
+  /** S3 key prefix. Defaults to a stable prefix derived from the database path. */
   prefix?: string;
   /** S3 endpoint URL, e.g. for Tigris or MinIO (mode = "s3"). */
   endpoint?: string;
@@ -58,6 +59,7 @@ export interface ConnectOptions {
 }
 
 let _vfsCounter = 0;
+const _s3VfsByFingerprint = new Map<string, string>();
 
 /**
  * Find the bundled loadable extension binary.
@@ -110,6 +112,29 @@ function addPlatformExt(basePath: string): string {
   return `${basePath}.${ext}`;
 }
 
+function s3Fingerprint(parts: Array<string | number | boolean | undefined | null>): string {
+  return parts
+    .map((part) => {
+      if (part == null) return '';
+      return String(part);
+    })
+    .join('\0');
+}
+
+function defaultS3VfsName(fingerprint: string): string {
+  return `turbolite-s3-${crypto
+    .createHash('sha256')
+    .update(fingerprint)
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function defaultS3Prefix(absPath: string): string {
+  const stem = path.basename(absPath) || 'database';
+  const digest = crypto.createHash('sha256').update(absPath).digest('hex').slice(0, 16);
+  return `turbolite/${stem}-${digest}`;
+}
+
 /**
  * Open a better-sqlite3 Database with a URI filename.
  *
@@ -149,22 +174,17 @@ function openUri(
 // Lazily created and kept alive for the process lifetime so that
 // turbolite_register_vfs() calls can be made at any time.
 let _bootstrap: Database.Database | null = null;
-let _loadedS3 = false;
 
 function ensureBootstrap(): Database.Database {
   if (_bootstrap) return _bootstrap;
   _bootstrap = new Database(':memory:');
   _bootstrap.loadExtension(findExt());
-  if (process.env.TURBOLITE_BUCKET) {
-    _loadedS3 = true;
-  }
   return _bootstrap;
 }
 
 /**
  * Load the turbolite extension into an existing better-sqlite3 Database.
- * Registers the "turbolite" VFS (local mode) globally. If TURBOLITE_BUCKET
- * is set, also registers "turbolite-s3".
+ * Registers the extension SQL helpers and default VFS entries.
  */
 export function load(db: Database.Database): void {
   db.loadExtension(findExt());
@@ -209,19 +229,22 @@ export function connect(
     throw new Error(`mode must be 'local' or 's3', got '${mode}'`);
   }
 
-  // Set env vars BEFORE loading the extension. The C init function checks
-  // TURBOLITE_BUCKET to decide whether to register turbolite-s3.
+  const effectiveBucket = bucket ?? process.env.TURBOLITE_BUCKET;
+  const absPath = path.resolve(dbPath);
+  const effectivePrefix =
+    prefix ?? process.env.TURBOLITE_PREFIX ?? defaultS3Prefix(absPath);
+  const effectiveEndpoint =
+    endpoint ??
+    process.env.TURBOLITE_ENDPOINT_URL ??
+    process.env.AWS_ENDPOINT_URL;
+  const effectiveRegion = region ?? process.env.TURBOLITE_REGION ?? process.env.AWS_REGION;
+
   if (mode === 's3') {
-    const effectiveBucket = bucket ?? process.env.TURBOLITE_BUCKET;
     if (!effectiveBucket) {
       throw new Error(
         "mode='s3' requires a bucket. Pass bucket or set TURBOLITE_BUCKET."
       );
     }
-    process.env.TURBOLITE_BUCKET = effectiveBucket;
-    if (prefix != null) process.env.TURBOLITE_PREFIX = prefix;
-    if (endpoint != null) process.env.TURBOLITE_ENDPOINT_URL = endpoint;
-    if (region != null) process.env.TURBOLITE_REGION = region;
     if (cacheDir != null) process.env.TURBOLITE_CACHE_DIR = cacheDir;
     if (readOnly) process.env.TURBOLITE_READ_ONLY = 'true';
   }
@@ -237,7 +260,6 @@ export function connect(
   // Ensure the extension is loaded (registers SQL functions + global VFS).
   const bootstrap = ensureBootstrap();
 
-  const absPath = path.resolve(dbPath);
   let vfsName: string;
 
   if (mode === 'local') {
@@ -261,15 +283,45 @@ export function connect(
       );
     }
   } else {
-    // S3 mode uses the global "turbolite-s3" VFS registered at init time.
-    if (!_loadedS3) {
+    const fingerprint = s3Fingerprint([
+      absPath,
+      effectiveBucket,
+      effectivePrefix,
+      effectiveEndpoint,
+      effectiveRegion,
+      cacheDir,
+      compressionLevel,
+      prefetchThreads,
+      readOnly,
+      pageCache,
+    ]);
+    let registered = _s3VfsByFingerprint.get(fingerprint);
+    if (!registered) {
+      registered = defaultS3VfsName(fingerprint);
+      const rc = bootstrap
+        .prepare('SELECT turbolite_register_s3_file_first_vfs(?, ?, ?, ?, ?, ?)')
+        .pluck()
+        .get(
+          registered,
+          absPath,
+          effectiveBucket,
+          effectivePrefix,
+          effectiveEndpoint ?? null,
+          effectiveRegion ?? null,
+        ) as number;
+      if (rc !== 0) {
+        throw new Error(
+          `Failed to register S3 file-first VFS '${registered}' for ${absPath}`
+        );
+      }
+      _s3VfsByFingerprint.set(fingerprint, registered);
+    }
+    if (!registered) {
       throw new Error(
-        'Cannot use S3 mode: TURBOLITE_BUCKET was not set when the extension ' +
-        'was first loaded. Set TURBOLITE_BUCKET in the environment before ' +
-        'the first turbolite.connect() call.'
+        `Failed to resolve S3 file-first VFS for ${absPath}`
       );
     }
-    vfsName = 'turbolite-s3';
+    vfsName = registered;
   }
 
   const db = openUri(`file:${absPath}?vfs=${vfsName}`, absPath, {

--- a/turbolite-ffi/packages/node/test.mjs
+++ b/turbolite-ffi/packages/node/test.mjs
@@ -14,8 +14,8 @@ import path from 'node:path';
 import os from 'node:os';
 
 // If TIERED_TEST_BUCKET is set but TURBOLITE_BUCKET is not, propagate it.
-// The turbolite extension checks TURBOLITE_BUCKET during init to decide
-// whether to register the S3 VFS. This must happen before any connect() call.
+// The wrapper resolves the effective bucket from TURBOLITE_BUCKET unless an
+// explicit bucket option is passed.
 if (process.env.TIERED_TEST_BUCKET && !process.env.TURBOLITE_BUCKET) {
   process.env.TURBOLITE_BUCKET = process.env.TIERED_TEST_BUCKET;
 }
@@ -605,6 +605,81 @@ if (bucket) {
     const row = db.prepare('SELECT val FROM counter WHERE id = 1').get();
     assert.equal(row.val, 50);
     db.close();
+  });
+
+  test('S3 two prefixes in one process do not cross', () => {
+    const root = testDir();
+    const basePrefix = `test/node-two-prefix-${Date.now()}`;
+    const dbA = connect(path.join(root, 'a.db'), {
+      mode: 's3',
+      bucket,
+      prefix: `${basePrefix}/a`,
+      endpoint: s3Endpoint || undefined,
+      region: 'auto',
+    });
+    const dbB = connect(path.join(root, 'b.db'), {
+      mode: 's3',
+      bucket,
+      prefix: `${basePrefix}/b`,
+      endpoint: s3Endpoint || undefined,
+      region: 'auto',
+    });
+
+    dbA.exec('CREATE TABLE marker (id INTEGER PRIMARY KEY, value TEXT)');
+    dbA.prepare('INSERT INTO marker VALUES (?, ?)').run(1, 'alpha');
+    dbA.pragma('wal_checkpoint(TRUNCATE)');
+
+    dbB.exec('CREATE TABLE marker (id INTEGER PRIMARY KEY, value TEXT)');
+    dbB.prepare('INSERT INTO marker VALUES (?, ?)').run(1, 'bravo');
+    dbB.pragma('wal_checkpoint(TRUNCATE)');
+
+    assert.equal(
+      dbA.prepare('SELECT value FROM marker WHERE id = 1').get().value,
+      'alpha'
+    );
+    assert.equal(
+      dbB.prepare('SELECT value FROM marker WHERE id = 1').get().value,
+      'bravo'
+    );
+
+    dbA.close();
+    dbB.close();
+  });
+
+  test('S3 default prefixes in one process do not cross', () => {
+    const root = testDir();
+    const dbA = connect(path.join(root, 'default-a.db'), {
+      mode: 's3',
+      bucket,
+      endpoint: s3Endpoint || undefined,
+      region: 'auto',
+    });
+    const dbB = connect(path.join(root, 'default-b.db'), {
+      mode: 's3',
+      bucket,
+      endpoint: s3Endpoint || undefined,
+      region: 'auto',
+    });
+
+    dbA.exec('CREATE TABLE marker (id INTEGER PRIMARY KEY, value TEXT)');
+    dbA.prepare('INSERT INTO marker VALUES (?, ?)').run(1, 'default-alpha');
+    dbA.pragma('wal_checkpoint(TRUNCATE)');
+
+    dbB.exec('CREATE TABLE marker (id INTEGER PRIMARY KEY, value TEXT)');
+    dbB.prepare('INSERT INTO marker VALUES (?, ?)').run(1, 'default-bravo');
+    dbB.pragma('wal_checkpoint(TRUNCATE)');
+
+    assert.equal(
+      dbA.prepare('SELECT value FROM marker WHERE id = 1').get().value,
+      'default-alpha'
+    );
+    assert.equal(
+      dbB.prepare('SELECT value FROM marker WHERE id = 1').get().value,
+      'default-bravo'
+    );
+
+    dbA.close();
+    dbB.close();
   });
 
   test('S3 requires bucket', () => {

--- a/turbolite-ffi/packages/python/test_turbolite.py
+++ b/turbolite-ffi/packages/python/test_turbolite.py
@@ -229,6 +229,97 @@ def test_s3_write_read():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_s3_two_prefixes_same_process_do_not_cross():
+    """S3 mode: two prefixes in one process must get distinct VFS identities."""
+    bucket = os.environ.get("TIERED_TEST_BUCKET") or os.environ.get("TURBOLITE_BUCKET")
+    if not bucket:
+        print("SKIP: S3 tests (no TIERED_TEST_BUCKET set)")
+        return
+
+    print("test: S3 two-prefix isolation in one process...")
+    d = tempfile.mkdtemp()
+    try:
+        prefix_base = f"test/python-isolation-{os.getpid()}"
+        conn_a = turbolite.connect(
+            os.path.join(d, "a.db"),
+            mode="s3",
+            bucket=bucket,
+            prefix=f"{prefix_base}/a",
+            endpoint=os.environ.get("AWS_ENDPOINT_URL"),
+            region="auto",
+            cache_dir=os.path.join(d, "a-cache"),
+        )
+        conn_b = turbolite.connect(
+            os.path.join(d, "b.db"),
+            mode="s3",
+            bucket=bucket,
+            prefix=f"{prefix_base}/b",
+            endpoint=os.environ.get("AWS_ENDPOINT_URL"),
+            region="auto",
+            cache_dir=os.path.join(d, "b-cache"),
+        )
+
+        conn_a.execute("CREATE TABLE marker (value TEXT)")
+        conn_a.execute("INSERT INTO marker VALUES ('from-a')")
+        conn_a.commit()
+        conn_b.execute("CREATE TABLE marker (value TEXT)")
+        conn_b.execute("INSERT INTO marker VALUES ('from-b')")
+        conn_b.commit()
+
+        assert conn_a.execute("SELECT value FROM marker").fetchone()[0] == "from-a"
+        assert conn_b.execute("SELECT value FROM marker").fetchone()[0] == "from-b"
+
+        conn_a.close()
+        conn_b.close()
+        print("  PASS")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_s3_default_prefixes_do_not_cross():
+    """S3 mode: two paths with default prefixes must not share remote state."""
+    bucket = os.environ.get("TIERED_TEST_BUCKET") or os.environ.get("TURBOLITE_BUCKET")
+    if not bucket:
+        print("SKIP: S3 tests (no TIERED_TEST_BUCKET set)")
+        return
+
+    print("test: S3 default-prefix isolation in one process...")
+    d = tempfile.mkdtemp()
+    try:
+        conn_a = turbolite.connect(
+            os.path.join(d, "default-a.db"),
+            mode="s3",
+            bucket=bucket,
+            endpoint=os.environ.get("AWS_ENDPOINT_URL"),
+            region="auto",
+            cache_dir=os.path.join(d, "default-a-cache"),
+        )
+        conn_b = turbolite.connect(
+            os.path.join(d, "default-b.db"),
+            mode="s3",
+            bucket=bucket,
+            endpoint=os.environ.get("AWS_ENDPOINT_URL"),
+            region="auto",
+            cache_dir=os.path.join(d, "default-b-cache"),
+        )
+
+        conn_a.execute("CREATE TABLE marker (value TEXT)")
+        conn_a.execute("INSERT INTO marker VALUES ('default-a')")
+        conn_a.commit()
+        conn_b.execute("CREATE TABLE marker (value TEXT)")
+        conn_b.execute("INSERT INTO marker VALUES ('default-b')")
+        conn_b.commit()
+
+        assert conn_a.execute("SELECT value FROM marker").fetchone()[0] == "default-a"
+        assert conn_b.execute("SELECT value FROM marker").fetchone()[0] == "default-b"
+
+        conn_a.close()
+        conn_b.close()
+        print("  PASS")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def test_s3_requires_bucket():
     """S3 mode without bucket should raise ValueError."""
     print("test: S3 mode requires bucket...")
@@ -246,10 +337,11 @@ def test_s3_requires_bucket():
 
 
 if __name__ == "__main__":
-    # S3 write test must run FIRST: the extension init only runs once per
-    # process, and TURBOLITE_BUCKET must be set before loading to register
-    # turbolite-s3. Local mode works regardless of load order.
+    # S3 tests can run before or after local tests: S3 mode now registers
+    # a per-volume VFS instead of relying on process-global turbolite-s3.
     test_s3_write_read()
+    test_s3_two_prefixes_same_process_do_not_cross()
+    test_s3_default_prefixes_do_not_cross()
     test_local_basic_crud()
     test_local_file_first_layout()
     test_local_relative_path()

--- a/turbolite-ffi/packages/python/turbolite/__init__.py
+++ b/turbolite-ffi/packages/python/turbolite/__init__.py
@@ -25,6 +25,7 @@ rejects the alias open of a different target file by design.
 from __future__ import annotations
 
 import itertools
+import hashlib
 import os
 import platform
 import sqlite3
@@ -37,6 +38,7 @@ __version__ = "0.4.1"
 # Each connect() call gets its own VFS so manifest/cache/sidecar state stays
 # pinned to one database file.
 _vfs_counter = itertools.count()
+_s3_vfs_by_fingerprint: dict[tuple[object, ...], str] = {}
 
 
 def _find_ext() -> str:
@@ -70,8 +72,8 @@ def load(conn: sqlite3.Connection) -> None:
     Load the turbolite extension into a sqlite3 connection.
 
     After loading, the "turbolite" VFS (local mode) is always registered.
-    If TURBOLITE_BUCKET is set in the environment, "turbolite-s3"
-    (S3 cloud mode) is also registered.
+    S3 connections register a per-volume VFS from explicit connect()
+    arguments; they do not rely on the process-global "turbolite-s3" VFS.
 
     Args:
         conn: Any open sqlite3.Connection (can be :memory:).
@@ -109,6 +111,45 @@ def state_dir_for_database_path(path: str) -> str:
     return f"{os.fspath(path)}-turbolite"
 
 
+def _s3_fingerprint(
+    *,
+    abs_path: str,
+    bucket: str,
+    prefix: str,
+    endpoint: str | None,
+    region: str | None,
+    cache_dir: str | None,
+    compression_level: int | None,
+    prefetch_threads: int | None,
+    read_only: bool,
+    page_cache: str,
+) -> tuple[object, ...]:
+    return (
+        abs_path,
+        bucket,
+        prefix,
+        endpoint or "",
+        region or "",
+        cache_dir or "",
+        compression_level or "",
+        prefetch_threads or "",
+        read_only,
+        page_cache,
+    )
+
+
+def _default_s3_vfs_name(fingerprint: tuple[object, ...]) -> str:
+    material = "\0".join(str(part) for part in fingerprint)
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"turbolite-s3-{digest}"
+
+
+def _default_s3_prefix(abs_path: str) -> str:
+    stem = os.path.basename(abs_path).replace("/", "_") or "database"
+    digest = hashlib.sha256(abs_path.encode("utf-8")).hexdigest()[:16]
+    return f"turbolite/{stem}-{digest}"
+
+
 def connect(
     path: str,
     *,
@@ -134,7 +175,8 @@ def connect(
         path: Path to the database file. May be relative or absolute.
         mode: "local" for local VFS, "s3" for S3 cloud VFS.
         bucket: S3 bucket (required for mode="s3", or set TURBOLITE_BUCKET).
-        prefix: S3 key prefix (default "turbolite").
+        prefix: S3 key prefix. Defaults to a stable prefix derived from the
+            database path, so distinct paths do not overlap in one bucket.
         endpoint: S3 endpoint URL (Tigris, MinIO). Falls back to AWS_ENDPOINT_URL.
         region: AWS region. Falls back to AWS_REGION.
         cache_dir: Lower-level override for the sidecar directory. When unset
@@ -163,21 +205,11 @@ def connect(
         )
 
     if mode == "s3":
-        # Set env vars BEFORE loading the extension. The C init function
-        # checks TURBOLITE_BUCKET to decide whether to register turbolite-s3.
-        # Once loaded, the VFS is registered for the process lifetime.
         effective_bucket = bucket or os.environ.get("TURBOLITE_BUCKET")
         if not effective_bucket:
             raise ValueError(
                 "mode='s3' requires a bucket. Pass bucket= or set TURBOLITE_BUCKET."
             )
-        os.environ["TURBOLITE_BUCKET"] = effective_bucket
-        if prefix is not None:
-            os.environ["TURBOLITE_PREFIX"] = prefix
-        if endpoint is not None:
-            os.environ["TURBOLITE_ENDPOINT_URL"] = endpoint
-        if region is not None:
-            os.environ["TURBOLITE_REGION"] = region
         if cache_dir is not None:
             os.environ["TURBOLITE_CACHE_DIR"] = cache_dir
         if read_only:
@@ -189,15 +221,9 @@ def connect(
         os.environ["TURBOLITE_PREFETCH_THREADS"] = str(prefetch_threads)
     os.environ["TURBOLITE_MEM_CACHE_BUDGET"] = page_cache
 
-    # Load the extension once. S3 env vars must be set BEFORE first load
-    # because the C init function only runs once per process.
-    if mode == "s3" and _loaded_local and not _loaded_s3:
-        raise RuntimeError(
-            "Cannot switch to S3 mode after local mode was already loaded. "
-            "The SQLite extension init only runs once per process. "
-            "Use mode='s3' on the first turbolite.connect() call, or set "
-            "TURBOLITE_BUCKET in the environment before importing turbolite."
-        )
+    # Load the extension once. S3 mode no longer depends on a fixed
+    # process-global VFS registered at extension load time; each S3 connect
+    # registers a per-volume VFS below.
     boot = _ensure_bootstrap()
 
     if mode == "local":
@@ -214,13 +240,48 @@ def connect(
                 f"turbolite: failed to register file-first VFS '{vfs}' for {abs_path}"
             )
     else:
-        if not _loaded_s3:
+        effective_bucket = bucket or os.environ.get("TURBOLITE_BUCKET")
+        if not effective_bucket:
             raise RuntimeError(
-                "Cannot use S3 mode: TURBOLITE_BUCKET was not set when the extension "
-                "was first loaded. Set TURBOLITE_BUCKET in the environment before "
-                "the first turbolite.connect() call."
+                "Cannot use S3 mode: pass bucket= or set TURBOLITE_BUCKET."
             )
-        vfs = "turbolite-s3"
+        effective_prefix = (
+            prefix or os.environ.get("TURBOLITE_PREFIX") or _default_s3_prefix(abs_path)
+        )
+        effective_endpoint = endpoint or os.environ.get("TURBOLITE_ENDPOINT_URL") or os.environ.get("AWS_ENDPOINT_URL")
+        effective_region = region or os.environ.get("TURBOLITE_REGION") or os.environ.get("AWS_REGION")
+        fingerprint = _s3_fingerprint(
+            abs_path=abs_path,
+            bucket=effective_bucket,
+            prefix=effective_prefix,
+            endpoint=effective_endpoint,
+            region=effective_region,
+            cache_dir=cache_dir,
+            compression_level=compression_level,
+            prefetch_threads=prefetch_threads,
+            read_only=read_only,
+            page_cache=page_cache,
+        )
+        vfs = _s3_vfs_by_fingerprint.get(fingerprint)
+        if vfs is None:
+            vfs = _default_s3_vfs_name(fingerprint)
+            rc = boot.execute(
+                "SELECT turbolite_register_s3_file_first_vfs(?, ?, ?, ?, ?, ?)",
+                (
+                    vfs,
+                    abs_path,
+                    effective_bucket,
+                    effective_prefix,
+                    effective_endpoint,
+                    effective_region,
+                ),
+            ).fetchone()[0]
+            if rc != 0:
+                raise RuntimeError(
+                    f"turbolite: failed to register file-first S3 VFS '{vfs}' "
+                    f"for {abs_path} at {effective_bucket}/{effective_prefix}"
+                )
+            _s3_vfs_by_fingerprint[fingerprint] = vfs
 
     conn = sqlite3.connect(f"file:{abs_path}?vfs={vfs}", uri=True)
 

--- a/turbolite-ffi/src/ext.rs
+++ b/turbolite-ffi/src/ext.rs
@@ -70,6 +70,17 @@ static BENCH_HANDLE: std::sync::OnceLock<turbolite::tiered::TurboliteSharedState
     std::sync::OnceLock::new();
 
 #[cfg(feature = "cli-s3")]
+static S3_RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+
+#[cfg(feature = "cli-s3")]
+fn s3_runtime() -> &'static tokio::runtime::Runtime {
+    S3_RUNTIME.get_or_init(|| {
+        tokio::runtime::Runtime::new()
+            .expect("turbolite: failed to build shared S3 registration runtime")
+    })
+}
+
+#[cfg(feature = "cli-s3")]
 #[derive(Default)]
 struct StorageCounters {
     gets: std::sync::atomic::AtomicU64,
@@ -796,8 +807,7 @@ pub extern "C" fn turbolite_ext_register_file_first_vfs(
         }
     };
 
-    let config =
-        turbolite::tiered::TurboliteConfig::from_env().with_database_path(db_path);
+    let config = turbolite::tiered::TurboliteConfig::from_env().with_database_path(db_path);
     match turbolite::tiered::TurboliteVfs::new_local(config) {
         Ok(vfs) => match turbolite::tiered::register(&name, vfs) {
             Ok(()) => 0,
@@ -817,6 +827,126 @@ pub extern "C" fn turbolite_ext_register_file_first_vfs(
             1
         }
     }
+}
+
+#[cfg(feature = "cli-s3")]
+fn optional_cstr(ptr: *const std::os::raw::c_char) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    unsafe { std::ffi::CStr::from_ptr(ptr).to_str().ok() }
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Register a file-first S3 VFS keyed to one logical volume.
+///
+/// Unlike the process-global `turbolite-s3` convenience VFS, this creates a
+/// VFS with caller-supplied name and caller-supplied bucket/prefix. Bindings
+/// that open many volumes in one process should use this path so each volume
+/// has a distinct VFS identity.
+#[cfg(feature = "cli-s3")]
+#[no_mangle]
+pub extern "C" fn turbolite_ext_register_s3_file_first_vfs(
+    name_ptr: *const std::os::raw::c_char,
+    db_path_ptr: *const std::os::raw::c_char,
+    bucket_ptr: *const std::os::raw::c_char,
+    prefix_ptr: *const std::os::raw::c_char,
+    endpoint_ptr: *const std::os::raw::c_char,
+    region_ptr: *const std::os::raw::c_char,
+) -> std::os::raw::c_int {
+    use std::sync::Arc;
+    use turbolite::tiered::{TurboliteConfig, TurboliteVfs};
+
+    let name = unsafe {
+        match std::ffi::CStr::from_ptr(name_ptr).to_str() {
+            Ok(s) if !s.is_empty() => s.to_string(),
+            _ => return 1,
+        }
+    };
+    let db_path = unsafe {
+        match std::ffi::CStr::from_ptr(db_path_ptr).to_str() {
+            Ok(s) if !s.is_empty() => std::path::PathBuf::from(s),
+            _ => return 1,
+        }
+    };
+    let bucket = unsafe {
+        match std::ffi::CStr::from_ptr(bucket_ptr).to_str() {
+            Ok(s) if !s.is_empty() => s.to_string(),
+            _ => return 1,
+        }
+    };
+    let prefix = optional_cstr(prefix_ptr).unwrap_or_else(|| "turbolite".to_string());
+    let endpoint_url = optional_cstr(endpoint_ptr);
+    let region = optional_cstr(region_ptr);
+
+    let handle = s3_runtime().handle().clone();
+    let backend = match handle.block_on(async {
+        hadb_storage_s3::S3Storage::from_env(bucket.clone(), endpoint_url.as_deref())
+            .await
+            .map(|storage| storage.with_prefix(prefix.clone()))
+    }) {
+        Ok(backend) => backend,
+        Err(e) => {
+            eprintln!(
+                "turbolite: failed to create S3 backend for VFS '{}': {}",
+                name, e
+            );
+            return 1;
+        }
+    };
+    let backend: Arc<dyn hadb_storage::StorageBackend> = Arc::new(backend);
+    let (counting_backend, counters_handle) = CountingStorageBackend::new(backend);
+    let backend: Arc<dyn hadb_storage::StorageBackend> = Arc::new(counting_backend);
+    {
+        let mut counters = s3_counters().lock().expect("s3 counter mutex poisoned");
+        counters.counters = Some(counters_handle);
+        counters.base_gets = 0;
+        counters.base_get_bytes = 0;
+        counters.base_puts = 0;
+        counters.base_put_bytes = 0;
+    }
+
+    let mut config = TurboliteConfig::from_env().with_database_path(db_path);
+    config.bucket = bucket;
+    config.prefix = prefix;
+    config.endpoint_url = endpoint_url;
+    config.region = region;
+
+    let vfs = match TurboliteVfs::with_backend(config, backend, handle) {
+        Ok(vfs) => vfs,
+        Err(e) => {
+            eprintln!(
+                "turbolite: failed to create file-first S3 VFS '{}': {}",
+                name, e
+            );
+            return 1;
+        }
+    };
+    match turbolite::tiered::register(&name, vfs) {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!(
+                "turbolite: failed to register file-first S3 VFS '{}': {}",
+                name, e
+            );
+            1
+        }
+    }
+}
+
+#[cfg(not(feature = "cli-s3"))]
+#[no_mangle]
+pub extern "C" fn turbolite_ext_register_s3_file_first_vfs(
+    _name_ptr: *const std::os::raw::c_char,
+    _db_path_ptr: *const std::os::raw::c_char,
+    _bucket_ptr: *const std::os::raw::c_char,
+    _prefix_ptr: *const std::os::raw::c_char,
+    _endpoint_ptr: *const std::os::raw::c_char,
+    _region_ptr: *const std::os::raw::c_char,
+) -> std::os::raw::c_int {
+    eprintln!("turbolite: file-first S3 VFS registration requires the 'cli-s3' feature");
+    1
 }
 
 #[cfg(not(feature = "cli-s3"))]

--- a/turbolite-ffi/src/ext_entry.c
+++ b/turbolite-ffi/src/ext_entry.c
@@ -34,6 +34,18 @@ extern int turbolite_ext_register_named_vfs(const char *name, const char *cache_
  * at `<db_path>-turbolite/`. Defined in src/ext.rs. */
 extern int turbolite_ext_register_file_first_vfs(const char *name, const char *db_path);
 
+/* Rust function -- registers a file-first S3 VFS keyed to one logical
+ * volume. Unlike the process-global "turbolite-s3" convenience VFS, this
+ * lets bindings create one VFS identity per bucket/prefix/db_path. */
+extern int turbolite_ext_register_s3_file_first_vfs(
+    const char *name,
+    const char *db_path,
+    const char *bucket,
+    const char *prefix,
+    const char *endpoint,
+    const char *region
+);
+
 /* Rust function -- runs EQP on SQL and pushes plan to global queue.
  * Defined in src/tiered/query_plan.rs. */
 extern void turbolite_trace_push_plan(sqlite3 *db, const char *sql);
@@ -137,6 +149,42 @@ static void turbolite_register_file_first_vfs_func(
         return;
     }
     int rc = turbolite_ext_register_file_first_vfs(name, db_path);
+    sqlite3_result_int(ctx, rc);
+}
+
+/*
+ * turbolite_register_s3_file_first_vfs(
+ *   name TEXT, db_path TEXT, bucket TEXT, prefix TEXT, endpoint TEXT, region TEXT
+ * )
+ *
+ * Register a file-first S3 VFS keyed to one logical volume. The caller's
+ * `db_path` is the local page image; sidecar metadata lives under
+ * `<db_path>-turbolite/`; remote objects live under the supplied
+ * bucket/prefix. This is the multi-volume-safe S3 entry point.
+ *
+ * Returns 0 on success, 1 on error.
+ */
+static void turbolite_register_s3_file_first_vfs_func(
+    sqlite3_context *ctx,
+    int argc,
+    sqlite3_value **argv
+) {
+    (void)argc;
+    const char *name = (const char *)sqlite3_value_text(argv[0]);
+    const char *db_path = (const char *)sqlite3_value_text(argv[1]);
+    const char *bucket = (const char *)sqlite3_value_text(argv[2]);
+    const char *prefix = (const char *)sqlite3_value_text(argv[3]);
+    const char *endpoint = (const char *)sqlite3_value_text(argv[4]);
+    const char *region = (const char *)sqlite3_value_text(argv[5]);
+    if (!name || !db_path || !bucket) {
+        sqlite3_result_error(
+            ctx,
+            "turbolite_register_s3_file_first_vfs: name, db_path, and bucket required",
+            -1);
+        return;
+    }
+    int rc = turbolite_ext_register_s3_file_first_vfs(
+        name, db_path, bucket, prefix, endpoint, region);
     sqlite3_result_int(ctx, rc);
 }
 
@@ -527,6 +575,18 @@ int turbolite_c_sqlite3_turbolite_init(
     if (rc != SQLITE_OK) {
         *pzErrMsg = sqlite3_mprintf(
             "turbolite: failed to register turbolite_register_file_first_vfs()");
+        return rc;
+    }
+
+    /* register turbolite_register_s3_file_first_vfs(...) SQL function.
+     * S3 file-first registration: one VFS per logical volume. */
+    rc = sqlite3_create_function_v2(
+        db, "turbolite_register_s3_file_first_vfs", 6,
+        SQLITE_UTF8, 0, turbolite_register_s3_file_first_vfs_func, 0, 0, 0
+    );
+    if (rc != SQLITE_OK) {
+        *pzErrMsg = sqlite3_mprintf(
+            "turbolite: failed to register turbolite_register_s3_file_first_vfs()");
         return rc;
     }
 

--- a/turbolite-ffi/src/ffi.rs
+++ b/turbolite-ffi/src/ffi.rs
@@ -299,10 +299,7 @@ pub extern "C" fn turbolite_register(name: *const c_char, config_json: *const c_
             return -1;
         }
     };
-    let cache_dir_present = raw
-        .get("cache_dir")
-        .map(|v| !v.is_null())
-        .unwrap_or(false);
+    let cache_dir_present = raw.get("cache_dir").map(|v| !v.is_null()).unwrap_or(false);
     let local_data_path_present = raw
         .get("local_data_path")
         .map(|v| !v.is_null())
@@ -318,11 +315,10 @@ pub extern "C" fn turbolite_register(name: *const c_char, config_json: *const c_
 
     if local_data_path_present && !cache_dir_present {
         if let Some(db_path) = config.local_data_path.clone() {
-            config.cache_dir =
-                turbolite::tiered::TurboliteConfig::state_dir_for_database_path(
-                    &db_path,
-                    "-turbolite",
-                );
+            config.cache_dir = turbolite::tiered::TurboliteConfig::state_dir_for_database_path(
+                &db_path,
+                "-turbolite",
+            );
         }
     }
 

--- a/turbolite-ffi/tests/crash_recovery.rs
+++ b/turbolite-ffi/tests/crash_recovery.rs
@@ -695,7 +695,6 @@ fn test_delete_mode_crash_recovery() {
     turbolite_close(db);
 }
 
-
 /// Regression test for the lock-downgrade-without-sync rollback bug.
 ///
 /// Earlier code in TurboliteHandle::lock() treated "lock downgrades from
@@ -733,10 +732,7 @@ fn test_persistence_across_synchronous_modes() {
         let db = open_db(&db_path_str, &vfs_name);
         exec_sql(db, &format!("PRAGMA journal_mode={journal}"));
         exec_sql(db, &format!("PRAGMA synchronous={sync}"));
-        exec_sql(
-            db,
-            "CREATE TABLE rows (id INTEGER PRIMARY KEY, val TEXT)",
-        );
+        exec_sql(db, "CREATE TABLE rows (id INTEGER PRIMARY KEY, val TEXT)");
         for i in 0..20 {
             exec_sql(db, &format!("INSERT INTO rows VALUES ({i}, 'v{i}')"));
         }
@@ -804,7 +800,6 @@ fn test_synchronous_off_multiple_commits_persist() {
     turbolite_close(db);
 }
 
-
 /// Rollback regression: the lock-downgrade-without-sync code path used
 /// to discard dirty pages on the assumption they were rolled-back
 /// in-progress writes. The new behavior unconditionally persists at
@@ -850,6 +845,9 @@ fn test_rollback_under_sync_off_keeps_pre_txn_state() {
         "no aborted rows must persist: {json}",
     );
     let json = query_json(db, "PRAGMA integrity_check");
-    assert!(json.contains("ok"), "integrity must pass after rollback: {json}");
+    assert!(
+        json.contains("ok"),
+        "integrity must pass after rollback: {json}"
+    );
     turbolite_close(db);
 }


### PR DESCRIPTION
## What changed

This removes the S3 binding footgun where package-level `connect(..., mode="s3")` paths all depended on the process-global `turbolite-s3` VFS. Python, Node, and Go now register a per-volume S3 file-first VFS through the loadable extension, keyed by the local database path plus bucket/prefix/endpoint/region/config.

Users can now open multiple S3-backed Turbolite databases in one process and get the obvious result: different paths/prefixes are different databases.

```python
import turbolite

a = turbolite.connect("/data/a.db", mode="s3", bucket="my-bucket", prefix="app/a")
b = turbolite.connect("/data/b.db", mode="s3", bucket="my-bucket", prefix="app/b")
```

Also fixed the default-prefix ergonomics. If a user omits `prefix`, the bindings derive a stable prefix from the database path instead of sending every default S3 connection to `turbolite/`.

```python
# These no longer collide remotely even without explicit prefixes.
a = turbolite.connect("/data/a.db", mode="s3", bucket="my-bucket")
b = turbolite.connect("/data/b.db", mode="s3", bucket="my-bucket")
```

## Implementation notes

- Added `turbolite_register_s3_file_first_vfs(name, db_path, bucket, prefix, endpoint, region)` to the loadable extension.
- Added a shared S3 runtime for per-volume registration instead of leaking/forgetting one runtime per volume.
- Updated Python, Node, and Go bindings to register/reuse stable hashed VFS names per S3 volume.
- Left the old process-global `turbolite-s3` convenience VFS in place, but documented it as single-volume only.
- Added real-S3 e2e coverage for explicit-prefix isolation and default-prefix isolation in Python, Node, and Go.

## Hostile self-review

- The old global `turbolite-s3` VFS still exists. That is fine for low-level/manual extension use, but product bindings should stay on the per-volume registration path.
- S3 bench/counter helpers are still process-global, so multi-volume observability is not yet clean. This PR fixes correctness/isolation, not per-volume metrics.
- Binding config still flows through some environment-backed Turbolite config fields during registration. Bucket/prefix are explicit now, but cache/compression/prefetch/page-cache config should eventually become fully argument-based too.
- Real-S3 tests are gated on `TIERED_TEST_BUCKET`/soup credentials, so CI needs a real/local S3-compatible environment to keep proving the important path.

## Proof

- `cargo fmt --check`
- `cargo check -p turbolite-ffi --features loadable-extension,cli-s3,zstd --no-default-features`
- `cargo test -p turbolite-ffi --features cli-s3,zstd`
- `python3 -m py_compile packages/python/turbolite/__init__.py packages/python/test_turbolite.py turbolite-ffi/packages/python/turbolite/__init__.py turbolite-ffi/packages/python/test_turbolite.py`
- `npm run build` in `turbolite-ffi/packages/node`
- `soup run -p turbolite -- python3 turbolite-ffi/packages/python/test_turbolite.py`
- `soup run -p turbolite -- go test .` in `turbolite-ffi/packages/go`
- `soup run -p turbolite -- sh -lc 'cd turbolite-ffi/packages/node && npm test'`
