### PR TITLE
Fix benchmark Docker build for Fly tiered-bench deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Keep the Docker build context small. The benchmark image only needs the
+# root crate (Cargo.toml/lock, src/, bin/) + benchmark/ + the turbolite-ffi
+# manifest/src for workspace parsing. Everything below is build artifacts,
+# language-binding packages, fixtures, or history that no build step reads.
+.git
+**/target
+examples
+fuzz
+docs
+vendor
+**/vendor
+**/node_modules
+packages
+turbolite-ffi/packages
+turbolite-ffi/tests
+**/*.db
+**/*.cache

--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -17,7 +17,10 @@ COPY Cargo.toml Cargo.lock* ./
 COPY src/ src/
 COPY bin/ bin/
 COPY benchmark/ benchmark/
-RUN cargo build --release --features tiered,zstd,bundled-sqlite --bin tiered-bench --bin tiered-tune
+# turbolite-ffi is a workspace member; cargo needs its manifest to parse the
+# workspace even though we only build the root crate's bench binaries.
+COPY turbolite-ffi/ turbolite-ffi/
+RUN cargo build --release --features bench-s3,zstd,bundled-sqlite --bin tiered-bench --bin tiered-tune
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates curl unzip && \


### PR DESCRIPTION
The `benchmark/Dockerfile` had drifted from the current crate and could no longer build, so the Fly `turbolite-tiered-bench` deploy was broken. Three fixes:

1. **Missing workspace member.** The workspace now includes `turbolite-ffi`, but the Dockerfile only copied `src/ bin/ benchmark/`, so cargo failed to parse the workspace (`failed to load manifest for workspace member /app/turbolite-ffi`). Now copies `turbolite-ffi/` — its manifest/src are needed for workspace parsing even though that crate isn't built for the bench binaries.

2. **Stale feature flag.** `--features tiered` no longer exists (`the package 'turbolite' does not contain this feature: tiered`). The S3-backed tiered bench is behind `bench-s3`. Switched to `--features bench-s3,zstd,bundled-sqlite` (both `tiered-bench` and `tiered-tune` declare `required-features = ["bench-s3"]`).

3. **Runaway build context.** With no `.dockerignore`, the entire repo was uploaded as build context (`turbolite-ffi/packages` 212 MB, `turbolite-ffi/tests` 87 MB, `examples/node` 86 MB, `.git` 75 MB — ~470 MB total), which exceeded the Fly remote builder's deadline mid-transfer. Added a `.dockerignore` trimming to the few MB the build actually reads.

### Verification

Deployed to `turbolite-tiered-bench` (perf-8x, iad, Tigris in-region) and ran the full 1M-row reproduction end to end:

- Generated 1M posts / 100K users / 2.5M friendships / 3M likes (1.46 GB), imported to S3 (97 page groups), `integrity_check: ok`, `COUNT(*) = 1,000,000`.
- Cold-tier (`none`) latencies in line with or better than the published README numbers (e.g. post+user 160 ms vs 192 ms, idx-filter 73 ms vs 173 ms, scan-filter 1.1 s vs 984 ms).
- Machine exited `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)