### PR TITLE
Pin sqlite-plugin to crates.io 0.10.1, drop the git fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,10 @@ wal = ["dep:walrust-core", "cli-s3"]
 lambda = ["dep:lambda_runtime", "bench-s3", "zstd"]
 
 [dependencies]
-# VFS backend. The forked branch carries the concurrent-WAL / iVersion fixes;
-# revisit upstreaming to orbitinghail/sqlite-plugin. `send_guard` makes
-# parking_lot guards Send so TurboliteHandle (which holds a replay-gate read
-# guard) satisfies sqlite-plugin's `VfsHandle: Send` bound.
-sqlite-plugin = { git = "https://github.com/russellromney/sqlite-plugin.git", branch = "fix/concurrent-wal-segfault", default-features = false, features = ["static"] }
+# VFS backend. `send_guard` makes parking_lot guards Send so TurboliteHandle
+# (which holds a replay-gate read guard) satisfies sqlite-plugin's
+# `VfsHandle: Send` bound.
+sqlite-plugin = { version = "0.10.1", default-features = false, features = ["static"] }
 zstd = { version = "0.13", optional = true }
 lz4_flex = { version = "0.11", optional = true }
 snap = { version = "1.1", optional = true }


### PR DESCRIPTION
The migration pinned `sqlite-plugin` to a git fork (`russellromney/sqlite-plugin@fix/concurrent-wal-segfault`) for fixes that weren't yet upstream. They are now: the xFetch/xUnfetch + iVersion=3 fix shipped in **orbitinghail/sqlite-plugin#81** and is released in crates.io **0.10.0 / 0.10.1**.

This pins the published `0.10.1` and drops the git dependency.

### Is anything lost?

The fork was `0.9.0` + 4 commits. Three (xFetch/xUnfetch, iVersion=3, the regression test) are equivalent to what landed upstream via #81. The only fork-unique change was an `x_close` tweak that nulls `pMethods` *after* `vfs.close()` rather than before (upstream still nulls it before — a Carl Sverre commit, not ours).

To check whether that tweak is load-bearing for turbolite, I ran the SEGFAULT-prone stress tests on `0.10.1` **without** it:

- `plugin_vfs_concurrent_wal_isolation` — **20/20** clean
- `plugin_vfs_cross_process_wal_isolation` — **15/15** clean

Zero failures, zero SEGFAULTs. The real fix was xFetch (now upstream); the `x_close` tweak was belt-and-suspenders for our usage.

### Verification on 0.10.1

- lib suite: **568 passed**
- loadable extension (Python): **27/27**
- concurrent (20×) + cross-process (15×) WAL isolation: clean

### Note

`walrust-core` (optional, behind the `wal` feature) is still a git dependency — so this doesn't by itself make turbolite crates.io-publishable, but it removes one of the two git deps. The `x_close` ordering remains a real (if non-load-bearing-for-us) upstream bug; sending it to orbitinghail is optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)