### PR TITLE
Clear all clippy warnings (style/lint cleanup)

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -20,13 +20,13 @@ pub fn compress(
 
     if let Some(encoder_dict) = encoder_dict {
         let mut encoder = zstd::stream::Encoder::with_prepared_dictionary(Vec::new(), encoder_dict)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
         encoder.write_all(data)?;
         encoder
             .finish()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     } else {
-        encode_all(data, level).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        encode_all(data, level).map_err(io::Error::other)
     }
 }
 
@@ -40,12 +40,12 @@ pub fn decompress(
 
     if let Some(decoder_dict) = decoder_dict {
         let mut decoder = zstd::stream::Decoder::with_prepared_dictionary(data, decoder_dict)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
         let mut output = Vec::new();
         decoder.read_to_end(&mut output)?;
         Ok(output)
     } else {
-        decode_all(data).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        decode_all(data).map_err(io::Error::other)
     }
 }
 
@@ -70,11 +70,11 @@ pub fn decompress_capped(
     let mut output = Vec::new();
     let n = if let Some(decoder_dict) = decoder_dict {
         let decoder = zstd::stream::Decoder::with_prepared_dictionary(data, decoder_dict)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
         decoder.take(cap as u64).read_to_end(&mut output)?
     } else {
         let decoder = zstd::stream::Decoder::new(data)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
         decoder.take(cap as u64).read_to_end(&mut output)?
     };
     if n > max_len {

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -46,8 +46,7 @@ pub fn train_dictionary(samples: &[Vec<u8>], dict_size: usize) -> io::Result<Vec
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
 
     from_samples(&sample_refs, dict_size).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::Other,
+        io::Error::other(
             format!("Dictionary training failed: {}", e),
         )
     })
@@ -101,11 +100,11 @@ pub fn compress_with_dict(data: &[u8], dict: &[u8], level: i32) -> io::Result<Ve
 
     let encoder_dict = EncoderDictionary::copy(dict, level);
     let mut encoder = zstd::stream::Encoder::with_prepared_dictionary(Vec::new(), &encoder_dict)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(io::Error::other)?;
     encoder.write_all(data)?;
     encoder
         .finish()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        .map_err(io::Error::other)
 }
 
 /// Decompress data using a dictionary.
@@ -116,7 +115,7 @@ pub fn decompress_with_dict(data: &[u8], dict: &[u8]) -> io::Result<Vec<u8>> {
 
     let decoder_dict = DecoderDictionary::copy(dict);
     let mut decoder = zstd::stream::Decoder::with_prepared_dictionary(data, &decoder_dict)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(io::Error::other)?;
     let mut output = Vec::new();
     decoder.read_to_end(&mut output)?;
     Ok(output)

--- a/src/install_hook.rs
+++ b/src/install_hook.rs
@@ -120,7 +120,7 @@ unsafe fn install(db: *mut ffi::sqlite3) {
 
     let queue_ptr = Arc::into_raw(queue) as *mut std::ffi::c_void;
 
-    let name = b"turbolite_config_set\0".as_ptr() as *const c_char;
+    let name = c"turbolite_config_set".as_ptr() as *const c_char;
     let rc = ffi::sqlite3_create_function_v2(
         db,
         name,
@@ -220,7 +220,7 @@ unsafe extern "C" fn destroy(ptr: *mut std::ffi::c_void) {
 /// connection was opened with `vfs=<some name passed to turbolite::tiered::register>`.
 unsafe fn connection_uses_turbolite_vfs(db: *mut ffi::sqlite3) -> bool {
     let mut vfs_ptr: *mut ffi::sqlite3_vfs = std::ptr::null_mut();
-    let main = b"main\0".as_ptr() as *const c_char;
+    let main = c"main".as_ptr() as *const c_char;
     let rc = ffi::sqlite3_file_control(
         db,
         main,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,12 @@
 //! turbolite::tiered::register("mydb", vfs)?;
 //! ```
 
+// The tiered storage pipeline threads many parameters (offsets, codecs,
+// counters, manifests) through its flush/compact/prefetch paths. Grouping them
+// into structs is a worthwhile refactor but a separate one; until then these
+// signatures are intentional, not an oversight.
+#![allow(clippy::too_many_arguments)]
+
 /// Debug logging macro. Emits a `tracing::debug!` event under the
 /// `turbolite` target. Users filter via `RUST_LOG=turbolite=debug` like any
 /// other tracing-instrumented library. Silent by default — no subscriber
@@ -144,7 +150,7 @@ pub fn connect(path: &str, config: TurboliteConfig) -> Result<rusqlite::Connecti
 /// # SQL function return codes
 ///
 /// - `0` — update queued successfully; the handle applies it on the next
-///    slow-path read.
+///   slow-path read.
 /// - SQL error — validation failed (unknown key or bad value). The
 ///   captured queue makes "no active handle" unreachable through this
 ///   function: the closure holds an `Arc` to its queue for the function's
@@ -314,7 +320,7 @@ const WAL_LOCK_OFFSET: u64 = 120;
 
 /// Lock tracing events are emitted under the `turbolite::locks` tracing
 /// target. Filter with `RUST_LOG=turbolite::locks=trace`.
-
+///
 /// The five SQLite database lock levels, ordered from weakest to strongest.
 /// Turbolite's own type (the VFS backend is sqlite-plugin; we no longer pull
 /// these from sqlite-vfs). See <https://www.sqlite.org/lockingv3.html>.
@@ -405,6 +411,7 @@ impl FileWalIndex {
                 .read(true)
                 .write(true)
                 .create(true)
+                .truncate(false)
                 .open(&self.path)?;
             self.file = Some(file);
         }
@@ -417,6 +424,7 @@ impl FileWalIndex {
                 .read(true)
                 .write(true)
                 .create(true)
+                .truncate(false)
                 .open(&self.path)?;
             self.lock_file = Some(std::sync::Arc::new(file));
         }

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -450,6 +450,7 @@ impl MainHandle {
         let lock_path = lock_path_for(&path);
         let lock_file = std::fs::OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(&lock_path)?;
@@ -588,8 +589,7 @@ fn decode_file(bytes: &[u8], codec: &PageCodec) -> Result<(Vec<u8>, u32), io::Er
     }
     // Exact-tail invariant: the directory occupies the remainder of the file.
     if dir_off
-        .checked_add(page_count * DIR_ENTRY_LEN)
-        .map_or(true, |end| end != bytes.len())
+        .checked_add(page_count * DIR_ENTRY_LEN) != Some(bytes.len())
     {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/src/tiered/bench.rs
+++ b/src/tiered/bench.rs
@@ -449,9 +449,7 @@ impl TurboliteSharedState {
         let mut groups_submitted = 0u32;
 
         let Some(ref pool) = self.prefetch_pool else {
-            return format!(
-                "{{\"trees_warmed\":[],\"groups_submitted\":0,\"note\":\"no prefetch pool (local mode)\"}}",
-            );
+            return "{\"trees_warmed\":[],\"groups_submitted\":0,\"note\":\"no prefetch pool (local mode)\"}".to_string();
         };
 
         for access in accesses {

--- a/src/tiered/cache_tracking.rs
+++ b/src/tiered/cache_tracking.rs
@@ -105,7 +105,7 @@ impl PageBitmap {
     /// but safe to call while readers use `is_present()` on existing pages
     /// (they only access indices < current len).
     pub(crate) fn resize(&mut self, page_count: u64) {
-        let needed_bytes = (page_count as usize + 7) / 8;
+        let needed_bytes = (page_count as usize).div_ceil(8);
         if self.bits.len() < needed_bytes {
             self.bits.resize_with(needed_bytes, || AtomicU8::new(0));
         }
@@ -309,7 +309,7 @@ impl SubChunkTracker {
     /// Correct for B-tree-aware groups where pages are non-positional.
     pub(crate) fn sub_chunk_id_for(&self, gid: u64, index_in_group: u32) -> SubChunkId {
         let spf = self.sub_pages_per_frame;
-        let frame_idx = if spf > 0 { index_in_group / spf } else { 0 };
+        let frame_idx = index_in_group.checked_div(spf).unwrap_or(0);
         SubChunkId {
             group_id: gid as u32,
             frame_index: frame_idx as u16,
@@ -647,8 +647,7 @@ impl SubChunkTracker {
             })
             .collect();
         let data = serde_json::to_vec(&entries).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 format!("serialize sub-chunk tracker: {}", e),
             )
         })?;

--- a/src/tiered/compact.rs
+++ b/src/tiered/compact.rs
@@ -425,11 +425,11 @@ pub(crate) fn compact_override_group(
             encryption_key,
         )?;
         let ps = page_size as usize;
-        for i in 0..group_size {
+        for (i, slot) in page_buffers.iter_mut().enumerate().take(group_size) {
             let start = i * ps;
             let end = start + ps;
             if end <= bulk_data.len() {
-                page_buffers[i] = Some(bulk_data[start..end].to_vec());
+                *slot = Some(bulk_data[start..end].to_vec());
             }
         }
     } else {
@@ -468,11 +468,11 @@ pub(crate) fn compact_override_group(
         let frame_start = frame_idx * sub_ppf as usize;
         let frame_end = std::cmp::min(frame_start + sub_ppf as usize, group_size);
         let ps = page_size as usize;
-        for pos in frame_start..frame_end {
-            let offset_in_frame = (pos - frame_start) * ps;
+        for (i, slot) in page_buffers[frame_start..frame_end].iter_mut().enumerate() {
+            let offset_in_frame = i * ps;
             let end = offset_in_frame + ps;
             if end <= decompressed.len() {
-                page_buffers[pos] = Some(decompressed[offset_in_frame..end].to_vec());
+                *slot = Some(decompressed[offset_in_frame..end].to_vec());
             }
         }
     }

--- a/src/tiered/config.rs
+++ b/src/tiered/config.rs
@@ -4,9 +4,11 @@ use super::*;
 
 /// Where to load the manifest on connection open.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum ManifestSource {
     /// Use local manifest if present, fall back to remote. Correct for single-writer.
     /// Checkpoints keep the local cache fresh; no remote fetch on warm reconnect.
+    #[default]
     Auto,
     /// Always fetch from the remote backend on open. For HA followers and
     /// multi-reader setups where another process may have checkpointed.
@@ -15,19 +17,16 @@ pub enum ManifestSource {
     S3,
 }
 
-impl Default for ManifestSource {
-    fn default() -> Self {
-        ManifestSource::Auto
-    }
-}
 
 // ===== Checkpoint mode =====
 
 /// How checkpoints interact with the configured storage backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum CheckpointMode {
     /// A SQLite checkpoint uploads dirty page groups to the backend before
     /// returning. This is the default durability mode.
+    #[default]
     Durable,
     /// A SQLite checkpoint commits into the local cache/staging log and returns
     /// without backend I/O. Call `flush_to_storage()` to publish the exact
@@ -35,11 +34,6 @@ pub enum CheckpointMode {
     LocalThenFlush,
 }
 
-impl Default for CheckpointMode {
-    fn default() -> Self {
-        CheckpointMode::Durable
-    }
-}
 
 // ===== Legacy sync mode =====
 
@@ -53,16 +47,14 @@ impl Default for CheckpointMode {
     note = "use TurboliteConfig.cache.checkpoint_mode instead"
 )]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default)]
+// S3Primary is the deprecated default; the derived Default references it on
+// purpose for back-compat with existing serialized configs.
+#[allow(deprecated)]
 pub enum SyncMode {
+    #[default]
     S3Primary,
     LocalThenFlush,
-}
-
-#[allow(deprecated)]
-impl Default for SyncMode {
-    fn default() -> Self {
-        SyncMode::S3Primary
-    }
 }
 
 // ===== Grouping strategy =====
@@ -70,19 +62,16 @@ impl Default for SyncMode {
 /// Grouping strategy marker. Only BTreeAware is supported.
 /// Kept as an enum for serde backward compatibility with existing manifests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum GroupingStrategy {
     /// Legacy positional mapping. No longer used for new databases.
     /// Existing Positional manifests are read-only compatible.
     Positional,
     /// B-tree-aware: explicit page-to-group mapping from btree walking.
+    #[default]
     BTreeAware,
 }
 
-impl Default for GroupingStrategy {
-    fn default() -> Self {
-        GroupingStrategy::BTreeAware
-    }
-}
 
 // ===== Group state for prefetch coordination =====
 
@@ -315,7 +304,6 @@ impl PrefetchConfig {
                     _ => ManifestSource::Auto,
                 })
                 .unwrap_or(d.manifest_source),
-            ..d
         }
     }
 }

--- a/src/tiered/disk_cache.rs
+++ b/src/tiered/disk_cache.rs
@@ -124,8 +124,7 @@ impl CacheIndex {
             next_offset: self.next_offset,
         })
         .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 format!("serialize cache index: {}", e),
             )
         })?;
@@ -393,6 +392,7 @@ impl DiskCache {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(cache_file_path)?;
         let cache_file_was_empty = cache_file.metadata()?.len() == 0;
 
@@ -488,7 +488,7 @@ impl DiskCache {
         }
 
         let total_groups = if pages_per_group > 0 && page_count > 0 {
-            ((page_count + pages_per_group as u64 - 1) / pages_per_group as u64) as usize
+            page_count.div_ceil(pages_per_group as u64) as usize
         } else {
             0
         };
@@ -564,7 +564,7 @@ impl DiskCache {
             cache_index: parking_lot::Mutex::new(cache_index),
             compaction_lock: parking_lot::RwLock::new(()),
             #[cfg(feature = "zstd")]
-            dictionary: dictionary.map(|d| Arc::new(d)),
+            dictionary: dictionary.map(Arc::new),
             stat_hits: AtomicU64::new(0),
             stat_misses: AtomicU64::new(0),
             stat_evictions: AtomicU64::new(0),
@@ -649,7 +649,7 @@ impl DiskCache {
                         self.mem_cache_bytes.fetch_add(ps as u64, Ordering::Relaxed);
                     } else {
                         unsafe {
-                            drop(Box::from_raw(std::slice::from_raw_parts_mut(new_ptr, ps)));
+                            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(new_ptr, ps)));
                         }
                     }
                 }
@@ -699,7 +699,7 @@ impl DiskCache {
                         self.mem_cache_bytes.fetch_add(ps as u64, Ordering::Relaxed);
                     } else {
                         unsafe {
-                            drop(Box::from_raw(std::slice::from_raw_parts_mut(new_ptr, ps)));
+                            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(new_ptr, ps)));
                         }
                     }
                 }
@@ -768,8 +768,7 @@ impl DiskCache {
         // cache back to consistent state. Until then, serving any
         // read would risk returning torn / inconsistent data.
         if self.tainted.load(Ordering::Acquire) {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 "DiskCache is tainted (replay rollback failed); restart the VFS to recover from the staging log",
             ));
         }
@@ -901,8 +900,7 @@ impl DiskCache {
         {
             let remaining = self.fail_no_visibility_after.fetch_sub(1, Ordering::SeqCst);
             if remaining <= 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     format!(
                         "test-injected forward write_page_no_visibility failure on page {}",
                         page_num
@@ -927,8 +925,7 @@ impl DiskCache {
         {
             let remaining = self.fail_rollback_after.fetch_sub(1, Ordering::SeqCst);
             if remaining <= 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     format!(
                         "test-injected rollback write_page_no_visibility failure on page {}",
                         page_num
@@ -1303,8 +1300,6 @@ impl DiskCache {
             } else {
                 page_data
             };
-            #[cfg(not(feature = "encryption"))]
-            let page_data = page_data;
             let offset = pnum * stride as u64;
             self.cache_file.write_all_at(page_data, offset)?;
         }
@@ -1507,7 +1502,7 @@ impl DiskCache {
         self.group_condvar.notify_all();
         // Lazy eviction check
         let count = EVICTION_COUNTER.fetch_add(1, Ordering::Relaxed);
-        if count % 64 == 0 {
+        if count.is_multiple_of(64) {
             drop(states);
             self.evict_expired();
             // Mid-query budget trim: TTL eviction alone (default off) lets a
@@ -1638,7 +1633,7 @@ impl DiskCache {
         drop(gp);
         let mut tracker = self.tracker.lock();
         let frames = if self.sub_pages_per_frame > 0 {
-            (num_pages + self.sub_pages_per_frame - 1) / self.sub_pages_per_frame
+            num_pages.div_ceil(self.sub_pages_per_frame)
         } else {
             1
         };
@@ -1760,7 +1755,7 @@ impl DiskCache {
                     if !old.is_null() && ps > 0 {
                         // Reconstruct the Box to defer its drop (no UAF risk)
                         let boxed =
-                            unsafe { Box::from_raw(std::slice::from_raw_parts_mut(old, ps)) };
+                            unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(old, ps)) };
                         self.deferred_frees.lock().push(boxed);
                         self.mem_cache_bytes.fetch_sub(ps as u64, Ordering::Relaxed);
                     }
@@ -2114,7 +2109,7 @@ impl DiskCache {
         drop(bitmap);
         let ppg = self.pages_per_group as u64;
         if ppg > 0 {
-            let group_count = (page_count + ppg - 1) / ppg;
+            let group_count = page_count.div_ceil(ppg);
             let states = self.group_states.lock();
             self.ensure_group_states_capacity(&states, group_count.saturating_sub(1));
             // Mark live groups Present and any group entirely above the new
@@ -2166,9 +2161,8 @@ impl DiskCache {
             }
         }
         let ppg = self.pages_per_group as u64;
-        if ppg > 0 {
+        if let Some(max_group) = max_page.checked_div(ppg) {
             let states = self.group_states.lock();
-            let max_group = max_page / ppg;
             self.ensure_group_states_capacity(&states, max_group);
             for &pnum in page_nums {
                 let gid = (pnum / ppg) as usize;
@@ -2209,7 +2203,7 @@ impl Drop for DiskCache {
                     let ptr = slot.swap(std::ptr::null_mut(), Ordering::Relaxed);
                     if !ptr.is_null() {
                         unsafe {
-                            drop(Box::from_raw(std::slice::from_raw_parts_mut(ptr, ps)));
+                            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, ps)));
                         }
                     }
                 }

--- a/src/tiered/encoding.rs
+++ b/src/tiered/encoding.rs
@@ -127,7 +127,7 @@ pub(crate) fn encode_page_group_seekable(
     // decoder later trusts to contain `group_page_nums.len()` entries).
     let page_count = pages.len();
 
-    let num_frames = (page_count + sub_ppg as usize - 1) / sub_ppg as usize;
+    let num_frames = page_count.div_ceil(sub_ppg as usize);
     let mut blob = Vec::new();
     let mut frame_table = Vec::with_capacity(num_frames);
 
@@ -219,7 +219,7 @@ pub(crate) fn decode_page_group_seekable_full(
     ) as u32;
     let mut output = Vec::with_capacity(actual_pages as usize * page_size as usize);
 
-    for (_frame_idx, entry) in frame_table.iter().enumerate() {
+    for entry in frame_table.iter() {
         let start = entry.offset as usize;
         let end = start + entry.len as usize;
         if end > data.len() {

--- a/src/tiered/flush.rs
+++ b/src/tiered/flush.rs
@@ -186,7 +186,7 @@ fn flush_inner(
     let effective_threshold = if override_threshold > 0 {
         override_threshold as usize
     } else if use_seekable && old_sub_ppf > 0 {
-        let frames_per_group = (ppg as usize + old_sub_ppf as usize - 1) / old_sub_ppf as usize;
+        let frames_per_group = (ppg as usize).div_ceil(old_sub_ppf as usize);
         std::cmp::max(1, frames_per_group / 4)
     } else {
         0

--- a/src/tiered/handle.rs
+++ b/src/tiered/handle.rs
@@ -434,8 +434,8 @@ impl TurboliteHandle {
             // Eagerly fetch page group 0 (contains schema + root page, hit on every query)
             if manifest.page_count > 0 && cache.group_state(0) != GroupState::Present {
                 if let Some(key) = manifest.page_group_keys.first() {
-                    if !key.is_empty() {
-                        if cache.try_claim_group(0) {
+                    if !key.is_empty()
+                        && cache.try_claim_group(0) {
                             // Capture replay epoch BEFORE the fetch so a
                             // finalize racing between this point and the
                             // cache write is detected.
@@ -453,7 +453,7 @@ impl TurboliteHandle {
                                 // readers.
                                 let mut override_writes: Vec<(Vec<u64>, Vec<u8>, u32)> = Vec::new();
                                 let gp0 = manifest.group_page_nums(0).into_owned();
-                                if let Some(overrides) = manifest.subframe_overrides.get(0) {
+                                if let Some(overrides) = manifest.subframe_overrides.first() {
                                     if !overrides.is_empty() && manifest.sub_pages_per_frame > 0 {
                                         let spf = manifest.sub_pages_per_frame as usize;
                                         for (&frame_idx, ovr) in overrides {
@@ -544,7 +544,6 @@ impl TurboliteHandle {
                                 cache.unclaim_if_fetching(0);
                             }
                         }
-                    }
                 }
             }
         } // end non-local eager fetch block (group 0 only)
@@ -1121,6 +1120,7 @@ impl TurboliteHandle {
                 .read(true)
                 .write(true)
                 .create(true)
+                .truncate(false)
                 .open(&lock_path)?;
             self.lock_file = Some(std::sync::Arc::new(file));
         }
@@ -1509,7 +1509,7 @@ impl DatabaseHandle for TurboliteHandle {
         // directory (backed by hadb-storage-local), decode, populate cache,
         // then read the page.
         if self.is_local {
-            if let (Some(ref storage), Some(ref runtime)) =
+            if let (Some(ref storage), Some(runtime)) =
                 (self.storage.as_ref(), self.runtime.as_ref())
             {
                 let manifest = (**self.manifest.load()).clone();
@@ -1979,8 +1979,7 @@ impl DatabaseHandle for TurboliteHandle {
                                 }
                                 Err(e) => {
                                     cache.unclaim_if_fetching(gid);
-                                    return Err(io::Error::new(
-                                        io::ErrorKind::Other,
+                                    return Err(io::Error::other(
                                         format!("S3 GET failed for gid={}: {}", gid, e),
                                     ));
                                 }
@@ -2260,7 +2259,7 @@ impl DatabaseHandle for TurboliteHandle {
                             let type_byte = if page_num == 0 {
                                 type_buf.get(100)
                             } else {
-                                type_buf.get(0)
+                                type_buf.first()
                             };
                             if let Some(&b) = type_byte {
                                 if b == 0x05 || b == 0x02 {
@@ -2307,8 +2306,7 @@ impl DatabaseHandle for TurboliteHandle {
                 // in their own sibling file, see persist_dirty_groups).
                 let m = (**self.manifest.load()).clone();
                 let manifest_bytes = rmp_serde::to_vec(&m).map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
+                    io::Error::other(
                         format!("serialize manifest for staging: {e}"),
                     )
                 })?;
@@ -2360,7 +2358,7 @@ impl DatabaseHandle for TurboliteHandle {
             //     network. `flush_to_storage()` drains pending_flushes later,
             //     outside the lock, via the same flush_dirty_groups path.
             if self.is_local {
-                if let (Some(ref storage), Some(ref runtime)) =
+                if let (Some(ref storage), Some(runtime)) =
                     (self.storage.as_ref(), self.runtime.as_ref())
                 {
                     let flush_res = flush::flush_dirty_groups(
@@ -2447,7 +2445,7 @@ impl DatabaseHandle for TurboliteHandle {
                             let mut new_group_pages: Vec<Vec<u64>> = Vec::new();
                             let mut btree_list: Vec<(&u64, &crate::btree_walker::BTreeEntry)> =
                                 walk.btrees.iter().collect();
-                            btree_list.sort_by(|a, b| b.1.pages.len().cmp(&a.1.pages.len()));
+                            btree_list.sort_by_key(|b| std::cmp::Reverse(b.1.pages.len()));
 
                             let threshold = std::cmp::max(ppg as usize / 4, 1);
                             let mut small_pages: Vec<u64> = Vec::new();
@@ -2816,7 +2814,7 @@ impl DatabaseHandle for TurboliteHandle {
                             let type_byte = if pnum == 0 {
                                 read_buf.get(100)
                             } else {
-                                read_buf.get(0)
+                                read_buf.first()
                             };
                             if let Some(&b) = type_byte {
                                 if b == 0x05 || b == 0x02 {
@@ -2829,8 +2827,7 @@ impl DatabaseHandle for TurboliteHandle {
                             }
                         }
                         Err(e) => {
-                            return Err(io::Error::new(
-                                io::ErrorKind::Other,
+                            return Err(io::Error::other(
                                 format!(
                                     "cache.read_page({}) failed during interior collection: {}",
                                     pnum, e
@@ -2959,8 +2956,7 @@ impl DatabaseHandle for TurboliteHandle {
                             }
                         }
                         Err(e) => {
-                            return Err(io::Error::new(
-                                io::ErrorKind::Other,
+                            return Err(io::Error::other(
                                 format!(
                                     "cache.read_page({}) failed during index leaf collection: {}",
                                     pnum, e
@@ -3245,8 +3241,7 @@ impl DatabaseHandle for TurboliteHandle {
             if let Some(cache) = &self.cache {
                 let m = (**self.manifest.load()).clone();
                 manifest::persist_manifest_local(&cache.cache_dir, &m).map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
+                    io::Error::other(
                         format!("local manifest persist failed after remote sync: {}", e),
                     )
                 })?;
@@ -3275,7 +3270,7 @@ impl DatabaseHandle for TurboliteHandle {
         let new_page_count = if size == 0 {
             0
         } else {
-            (size + page_size as u64 - 1) / page_size as u64
+            size.div_ceil(page_size as u64)
         };
 
         let old_page_count = self.manifest.load().page_count;
@@ -3298,9 +3293,7 @@ impl DatabaseHandle for TurboliteHandle {
         // file resize (slot-stride aware under encryption) and bit clearing.
         if let Some(cache) = &self.cache {
             if new_page_count < old_page_count {
-                if let Err(e) = cache.truncate_to_page_count(new_page_count, page_size) {
-                    return Err(e);
-                }
+                cache.truncate_to_page_count(new_page_count, page_size)?;
                 self.cached_generation = cache.bump_generation();
             }
         }
@@ -3510,8 +3503,7 @@ impl DatabaseHandle for TurboliteHandle {
                                     .insert("shared".to_string(), Box::new(guard));
                             }
                             Err(restore_err) => {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::Other,
+                                return Err(io::Error::other(
                                     format!("Lock restore failed: {}", restore_err),
                                 ));
                             }

--- a/src/tiered/import.rs
+++ b/src/tiered/import.rs
@@ -45,9 +45,9 @@ pub fn import_sqlite_file(
     } else {
         raw_page_size as u32
     };
-    let page_count = (file_len / page_size as u64) as u64;
+    let page_count = file_len / page_size as u64;
     let ppg = config.cache.pages_per_group;
-    let total_groups = (page_count + ppg as u64 - 1) / ppg as u64;
+    let total_groups = page_count.div_ceil(ppg as u64);
 
     eprintln!(
         "[import] file={} size={:.1}MB page_size={} pages={} groups={}",
@@ -99,7 +99,7 @@ pub fn import_sqlite_file(
         // Sort B-trees by size descending (large first)
         let mut btree_list: Vec<(&u64, &crate::btree_walker::BTreeEntry)> =
             walk_result.btrees.iter().collect();
-        btree_list.sort_by(|a, b| b.1.pages.len().cmp(&a.1.pages.len()));
+        btree_list.sort_by_key(|b| std::cmp::Reverse(b.1.pages.len()));
 
         let threshold = std::cmp::max(ppg as usize / 4, 1);
         let mut small_pages: Vec<u64> = Vec::new();

--- a/src/tiered/local_state.rs
+++ b/src/tiered/local_state.rs
@@ -80,8 +80,7 @@ pub(crate) fn persist(cache_dir: &Path, state: &LocalState) -> io::Result<()> {
     let mut state = state.clone().normalized();
     state.format_version = 1;
     let data = rmp_serde::to_vec(&state).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::Other,
+        io::Error::other(
             format!("serialize local_state.msgpack: {e}"),
         )
     })?;
@@ -129,6 +128,7 @@ where
     let _guard = lock.lock().expect("local_state update lock poisoned");
     let file_lock = FsOpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(lock_file_path(cache_dir))?;

--- a/src/tiered/manifest.rs
+++ b/src/tiered/manifest.rs
@@ -311,7 +311,7 @@ impl Manifest {
         if self.pages_per_group == 0 || self.page_count == 0 {
             return 0;
         }
-        (self.page_count + self.pages_per_group as u64 - 1) / self.pages_per_group as u64
+        self.page_count.div_ceil(self.pages_per_group as u64)
     }
 
     /// Build the reverse index (page_num -> PageLocation) from group_pages.
@@ -344,7 +344,7 @@ impl Manifest {
             }
         }
         // Build btree_groups + page_to_tree_name + tree_name_to_groups from B-tree manifest entries
-        for (_, entry) in &self.btrees {
+        for entry in self.btrees.values() {
             for &gid in &entry.group_ids {
                 self.btree_groups.insert(gid, entry.group_ids.clone());
                 self.group_to_tree_name.insert(gid, entry.name.clone());

--- a/src/tiered/mod.rs
+++ b/src/tiered/mod.rs
@@ -209,7 +209,7 @@ pub fn get_manifest(
     runtime: &tokio::runtime::Handle,
 ) -> std::io::Result<Option<Manifest>> {
     let bytes = async_rt::block_on(runtime, backend.get(keys::MANIFEST_KEY)).map_err(|e| {
-        std::io::Error::new(std::io::ErrorKind::Other, format!("fetch manifest: {e}"))
+        std::io::Error::other(format!("fetch manifest: {e}"))
     })?;
     match bytes {
         None => Ok(None),
@@ -527,8 +527,7 @@ pub fn turbolite_migrate_to_s3_primary(conn: &rusqlite::Connection) -> Result<()
     let current_mode: String = conn
         .query_row("PRAGMA journal_mode", [], |r| r.get(0))
         .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 format!("failed to read journal_mode: {}", e),
             )
         })?;
@@ -541,7 +540,7 @@ pub fn turbolite_migrate_to_s3_primary(conn: &rusqlite::Connection) -> Result<()
         // Checkpoint to flush WAL contents into the main database file
         conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
             .map_err(|e| {
-                io::Error::new(io::ErrorKind::Other, format!("checkpoint failed: {}", e))
+                io::Error::other(format!("checkpoint failed: {}", e))
             })?;
     }
 
@@ -572,8 +571,7 @@ pub fn turbolite_migrate_to_s3_primary(conn: &rusqlite::Connection) -> Result<()
 
     // We cannot modify page 0 via SQL (it is read-only in the database header).
     // Return an error so the caller knows manual steps are needed.
-    Err(io::Error::new(
-        io::ErrorKind::Other,
+    Err(io::Error::other(
         format!(
             "PRAGMA journal_mode=OFF returned '{}'. WAL checkpoint complete, but manual steps required: \
              1) Close this connection, \

--- a/src/tiered/query_plan.rs
+++ b/src/tiered/query_plan.rs
@@ -140,8 +140,8 @@ pub fn parse_eqp_output(eqp_text: &str) -> Vec<PlannedAccess> {
         let constraint_columns = extract_constraint_columns(rest);
 
         // For SCAN: always emit the table (we need all data groups)
-        if access_type == AccessType::Scan {
-            if seen.insert((table_name.to_string(), AccessType::Scan)) {
+        if access_type == AccessType::Scan
+            && seen.insert((table_name.to_string(), AccessType::Scan)) {
                 accesses.push(PlannedAccess {
                     tree_name: table_name.to_string(),
                     access_type: AccessType::Scan,
@@ -149,7 +149,6 @@ pub fn parse_eqp_output(eqp_text: &str) -> Vec<PlannedAccess> {
                     constraint_columns: constraint_columns.clone(),
                 });
             }
-        }
 
         // Check for USING [COVERING] INDEX <index_name>
         if let Some(idx_pos) = rest
@@ -167,10 +166,7 @@ pub fn parse_eqp_output(eqp_text: &str) -> Vec<PlannedAccess> {
                 .get(idx_name_start..)
                 .and_then(|s| s.split_whitespace().next())
             {
-                let idx_access = match access_type {
-                    AccessType::Search => AccessType::Search,
-                    AccessType::Scan => AccessType::Scan,
-                };
+                let idx_access = access_type;
                 if seen.insert((idx_name.to_string(), idx_access)) {
                     accesses.push(PlannedAccess {
                         tree_name: idx_name.to_string(),
@@ -254,8 +250,8 @@ pub unsafe fn run_eqp_and_parse(db: *mut std::ffi::c_void, sql: &str) -> Vec<Pla
         db,
         c_sql.as_ptr(),
         -1,
-        &mut stmt as *mut *mut std::ffi::c_void as *mut *mut _,
-        &mut tail as *mut *const std::ffi::c_char as *mut *const _,
+        &mut stmt as *mut *mut std::ffi::c_void,
+        &mut tail as *mut *const std::ffi::c_char,
     );
     if rc != 0 || stmt.is_null() {
         return Vec::new();

--- a/src/tiered/replay.rs
+++ b/src/tiered/replay.rs
@@ -78,8 +78,7 @@ fn handle_commit_phase_failure(
     match rollback_pre_images(cache, pre_images) {
         RollbackOutcome::AllRestored => {
             let _ = std::fs::remove_file(staging_log_path);
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 format!(
                     "{primary_msg} (rolled back {} pre-images; staging log {} removed; cache consistent)",
                     pre_images.len(),
@@ -95,8 +94,7 @@ fn handle_commit_phase_failure(
             cache
                 .tainted
                 .store(true, std::sync::atomic::Ordering::Release);
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 format!(
                     "{primary_msg} (rollback FAILED for {} of {} pre-images at pages {:?}; staging log {} KEPT for restart recovery; cache TAINTED)",
                     failed_pages.len(),
@@ -721,8 +719,7 @@ impl ReplayHandle {
             .pending_flushes
             .lock()
             .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
+                io::Error::other(
                     format!("pending_flushes poisoned: {e}"),
                 )
             })?
@@ -838,8 +835,7 @@ impl ReplayHandle {
 
     fn check_not_consumed(&self, method: &str) -> io::Result<()> {
         if self.consumed {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 format!("ReplayHandle::{method} called after finalize/abort"),
             ));
         }

--- a/src/tiered/staging.rs
+++ b/src/tiered/staging.rs
@@ -464,8 +464,8 @@ mod tests {
 
         // Write 2 pages + manifest trailer
         let mut writer = StagingWriter::open(&staging_dir, 1, 64).unwrap();
-        writer.append(0, &vec![10u8; 64]).unwrap();
-        writer.append(1, &vec![20u8; 64]).unwrap();
+        writer.append(0, &[10u8; 64]).unwrap();
+        writer.append(1, &[20u8; 64]).unwrap();
         writer.append_manifest(b"test-manifest-data").unwrap();
         let (path, pages) = writer.finalize().unwrap();
         assert_eq!(pages, 2);
@@ -485,7 +485,7 @@ mod tests {
 
         // Write a staging log with manifest trailer (non-multiple of record_size)
         let mut writer = StagingWriter::open(&staging_dir, 42, 64).unwrap();
-        writer.append(0, &vec![1u8; 64]).unwrap();
+        writer.append(0, &[1u8; 64]).unwrap();
         writer.append_manifest(b"some-manifest").unwrap();
         let (_path, _) = writer.finalize().unwrap();
 

--- a/src/tiered/storage.rs
+++ b/src/tiered/storage.rs
@@ -31,7 +31,7 @@ pub(crate) fn get_page_group(
     key: &str,
 ) -> io::Result<Option<Vec<u8>>> {
     block_on(runtime, backend.get(key))
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("storage get {key}: {e}")))
+        .map_err(|e| io::Error::other(format!("storage get {key}: {e}")))
 }
 
 /// Fetch a byte range from an object. `start`/`len` semantics match the
@@ -44,8 +44,7 @@ pub(crate) fn range_get(
     len: u32,
 ) -> io::Result<Option<Vec<u8>>> {
     block_on(runtime, backend.range_get(key, start, len)).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::Other,
+        io::Error::other(
             format!("storage range_get {key}: {e}"),
         )
     })
@@ -63,7 +62,7 @@ pub(crate) fn put_page_groups(
         return Ok(());
     }
     block_on(runtime, backend.put_many(uploads))
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("storage put_many: {e}")))
+        .map_err(|e| io::Error::other(format!("storage put_many: {e}")))
 }
 
 /// Single-key put. Thin wrapper over `StorageBackend::put`.
@@ -74,7 +73,7 @@ pub(crate) fn put(
     data: &[u8],
 ) -> io::Result<()> {
     block_on(runtime, backend.put(key, data))
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("storage put {key}: {e}")))
+        .map_err(|e| io::Error::other(format!("storage put {key}: {e}")))
 }
 
 /// Batch delete. See `StorageBackend::delete_many`.
@@ -87,7 +86,7 @@ pub(crate) fn delete_objects(
         return Ok(0);
     }
     block_on(runtime, backend.delete_many(keys_))
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("storage delete_many: {e}")))
+        .map_err(|e| io::Error::other(format!("storage delete_many: {e}")))
 }
 
 /// List all keys. Paginates under the hood via the trait's `after` cursor.
@@ -111,7 +110,7 @@ pub(crate) fn list_all_keys_with_prefix(
             let batch = backend
                 .list(prefix, after.as_deref())
                 .await
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("storage list: {e}")))?;
+                .map_err(|e| io::Error::other(format!("storage list: {e}")))?;
             if batch.is_empty() {
                 break;
             }
@@ -127,8 +126,7 @@ pub(crate) fn list_all_keys_with_prefix(
             // Guard against pathological backends that always return at
             // least one key.
             if out.len() > 10_000_000 {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     "list overran 10M keys",
                 ));
             }
@@ -163,7 +161,7 @@ pub(crate) fn put_manifest(
     manifest: &Manifest,
 ) -> io::Result<()> {
     let bytes = rmp_serde::to_vec(manifest)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("encode manifest: {e}")))?;
+        .map_err(|e| io::Error::other(format!("encode manifest: {e}")))?;
     put(backend, runtime, keys::MANIFEST_KEY, &bytes)
 }
 
@@ -185,8 +183,7 @@ pub(crate) fn get_page_groups_by_key(
                 }
                 Ok(None) => {}
                 Err(e) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
+                    return Err(io::Error::other(
                         format!("storage get {k}: {e}"),
                     ));
                 }
@@ -204,5 +201,5 @@ pub(crate) fn manifest_exists(
     runtime: &TokioHandle,
 ) -> io::Result<bool> {
     block_on(runtime, backend.exists(keys::MANIFEST_KEY))
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("storage exists: {e}")))
+        .map_err(|e| io::Error::other(format!("storage exists: {e}")))
 }

--- a/src/tiered/test_disk_cache.rs
+++ b/src/tiered/test_disk_cache.rs
@@ -8,7 +8,7 @@ fn positional_group_pages(pages_per_group: u32, page_count: u64) -> Vec<Vec<u64>
     if ppg == 0 || page_count == 0 {
         return Vec::new();
     }
-    let num_groups = (page_count + ppg - 1) / ppg;
+    let num_groups = page_count.div_ceil(ppg);
     (0..num_groups)
         .map(|g| {
             let start = g * ppg;
@@ -102,7 +102,7 @@ fn test_bitmap_large_page_numbers() {
     assert!(!bm.is_present(big - 1));
     assert!(!bm.is_present(big + 1));
     // Bitmap should be big enough
-    assert!(bm.bits.len() >= (big as usize / 8) + 1);
+    assert!(bm.bits.len() > (big as usize / 8));
 }
 
 #[test]
@@ -111,7 +111,7 @@ fn test_bitmap_ensure_capacity_auto_extends() {
     let mut bm = PageBitmap::new(dir.path().join("bm"));
     assert_eq!(bm.bits.len(), 0);
     bm.ensure_capacity(0);
-    assert!(bm.bits.len() >= 1);
+    assert!(!bm.bits.is_empty());
     bm.mark_present(0);
     assert!(bm.is_present(0));
     bm.ensure_capacity(255);
@@ -231,7 +231,7 @@ fn test_disk_cache_write_multiple_pages() {
     let dir = TempDir::new().unwrap();
     let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 16, None, Vec::new()).unwrap();
     for i in 0..16u64 {
-        cache.write_page(i, &vec![i as u8; 64]).unwrap();
+        cache.write_page(i, &[i as u8; 64]).unwrap();
     }
     for i in 0..16u64 {
         assert!(cache.is_present(i));
@@ -245,8 +245,8 @@ fn test_disk_cache_write_multiple_pages() {
 fn test_disk_cache_write_page_overwrite() {
     let dir = TempDir::new().unwrap();
     let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 8, None, Vec::new()).unwrap();
-    cache.write_page(3, &vec![0xAA; 64]).unwrap();
-    cache.write_page(3, &vec![0xBB; 64]).unwrap(); // overwrite
+    cache.write_page(3, &[0xAA; 64]).unwrap();
+    cache.write_page(3, &[0xBB; 64]).unwrap(); // overwrite
     let mut buf = vec![0u8; 64];
     cache.read_page(3, &mut buf).unwrap();
     assert_eq!(buf, vec![0xBB; 64]);
@@ -257,7 +257,7 @@ fn test_disk_cache_write_extends_file() {
     let dir = TempDir::new().unwrap();
     let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 0, None, Vec::new()).unwrap(); // page_count=0
                                                                                           // Writing page 10 should extend the file
-    cache.write_page(10, &vec![42u8; 64]).unwrap();
+    cache.write_page(10, &[42u8; 64]).unwrap();
     assert!(cache.is_present(10));
     let mut buf = vec![0u8; 64];
     cache.read_page(10, &mut buf).unwrap();
@@ -382,7 +382,7 @@ fn test_disk_cache_evict_group_clears_bitmap_and_state() {
     let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 16, None, gp).unwrap();
     // Write pages in group 0 (pages 0-3)
     for i in 0..4u64 {
-        cache.write_page(i, &vec![i as u8; 64]).unwrap();
+        cache.write_page(i, &[i as u8; 64]).unwrap();
     }
     cache.try_claim_group(0);
     cache.mark_group_present(0);
@@ -406,7 +406,7 @@ fn test_disk_cache_evict_group_preserves_other_groups() {
     let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 16, None, gp).unwrap();
     // Write pages in groups 0 and 1
     for i in 0..8u64 {
-        cache.write_page(i, &vec![i as u8; 64]).unwrap();
+        cache.write_page(i, &[i as u8; 64]).unwrap();
     }
     cache.evict_group(0); // Evict only group 0
     assert!(!cache.is_present(0));
@@ -423,7 +423,7 @@ fn test_disk_cache_evict_expired_with_real_ttl() {
 
     // Write and touch group 0
     for i in 0..4u64 {
-        cache.write_page(i, &vec![i as u8; 64]).unwrap();
+        cache.write_page(i, &[i as u8; 64]).unwrap();
     }
     cache.try_claim_group(0);
     cache.mark_group_present(0);
@@ -446,7 +446,7 @@ fn test_disk_cache_evict_expired_protects_interior() {
     let cache = DiskCache::new(dir.path(), 1, 4, 2, 64, 16, None, gp).unwrap(); // TTL = 1s
 
     for i in 0..8u64 {
-        cache.write_page(i, &vec![i as u8; 64]).unwrap();
+        cache.write_page(i, &[i as u8; 64]).unwrap();
     }
     cache.try_claim_group(0);
     cache.mark_group_present(0);
@@ -589,7 +589,7 @@ fn test_disk_cache_bitmap_persistence() {
     let dir = TempDir::new().unwrap();
     {
         let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 8, None, Vec::new()).unwrap();
-        cache.write_page(3, &vec![1u8; 64]).unwrap();
+        cache.write_page(3, &[1u8; 64]).unwrap();
         cache.persist_bitmap().unwrap();
     }
     let cache2 = DiskCache::new(dir.path(), 3600, 4, 2, 64, 8, None, Vec::new()).unwrap();
@@ -602,7 +602,7 @@ fn test_disk_cache_persists_unified_local_state() {
     let dir = TempDir::new().unwrap();
     {
         let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 8, None, Vec::new()).unwrap();
-        cache.write_page(3, &vec![1u8; 64]).unwrap();
+        cache.write_page(3, &[1u8; 64]).unwrap();
         cache.persist_bitmap().unwrap();
     }
 
@@ -659,7 +659,7 @@ fn test_disk_cache_reopen_initializes_group_states_from_bitmap() {
         let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 16, None, gp.clone()).unwrap();
         // Write ALL pages in group 0 (pages 0-3)
         for i in 0..4u64 {
-            cache.write_page(i, &vec![i as u8; 64]).unwrap();
+            cache.write_page(i, &[i as u8; 64]).unwrap();
         }
         cache.persist_bitmap().unwrap();
     }
@@ -676,8 +676,8 @@ fn test_disk_cache_reopen_partial_group_is_none() {
     {
         let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 16, None, Vec::new()).unwrap();
         // Write only 2 of 4 pages in group 0
-        cache.write_page(0, &vec![0u8; 64]).unwrap();
-        cache.write_page(1, &vec![1u8; 64]).unwrap();
+        cache.write_page(0, &[0u8; 64]).unwrap();
+        cache.write_page(1, &[1u8; 64]).unwrap();
         cache.persist_bitmap().unwrap();
     }
     let cache2 = DiskCache::new(dir.path(), 3600, 4, 2, 64, 16, None, Vec::new()).unwrap();
@@ -912,18 +912,18 @@ fn test_disk_cache_sub_chunk_boundary_pages() {
     let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 8, None, Vec::new()).unwrap();
 
     // Write frame 0 of group 0 (pages 0,1)
-    cache.write_pages_bulk(0, &vec![1u8; 128], 2).unwrap();
+    cache.write_pages_bulk(0, &[1u8; 128], 2).unwrap();
     assert!(cache.is_present(0));
     assert!(cache.is_present(1));
     assert!(!cache.is_present(2)); // frame 1
 
     // Write frame 1 of group 0 (pages 2,3)
-    cache.write_pages_bulk(2, &vec![2u8; 128], 2).unwrap();
+    cache.write_pages_bulk(2, &[2u8; 128], 2).unwrap();
     assert!(cache.is_present(2));
     assert!(cache.is_present(3));
 
     // Write frame 0 of group 1 (pages 4,5)
-    cache.write_pages_bulk(4, &vec![3u8; 128], 2).unwrap();
+    cache.write_pages_bulk(4, &[3u8; 128], 2).unwrap();
     assert!(cache.is_present(4));
     assert!(cache.is_present(5));
     assert!(!cache.is_present(6)); // frame 1 of group 1
@@ -1050,7 +1050,7 @@ fn test_wait_for_group_returns_on_reset_to_none() {
     std::thread::sleep(Duration::from_millis(10));
     {
         let states = cache.group_states.lock();
-        if let Some(s) = states.get(0) {
+        if let Some(s) = states.first() {
             s.store(GroupState::None as u8, Ordering::Release);
         }
     }
@@ -1550,7 +1550,7 @@ fn test_compressed_single_write_marks_tracker() {
     let dir = TempDir::new().unwrap();
     let cache = compressed_cache(dir.path(), 64, 16);
     let before = cache.cache_bytes();
-    cache.write_page(0, &vec![0xABu8; 64]).unwrap();
+    cache.write_page(0, &[0xABu8; 64]).unwrap();
     assert!(
         cache.cache_bytes() > before,
         "single compressed write must register bytes in the tracker"
@@ -1775,7 +1775,7 @@ fn test_compressed_index_persistence() {
     {
         let cache = compressed_cache(dir.path(), 64, 16);
         for p in 0..4u64 {
-            let data: Vec<u8> = (0..64).map(|i| (p as u8 + i) as u8).collect();
+            let data: Vec<u8> = (0..64).map(|i| (p as u8 + i)).collect();
             cache.write_page(p, &data).unwrap();
         }
         cache.persist_bitmap().unwrap();
@@ -1790,7 +1790,7 @@ fn test_compressed_index_persistence() {
                 "page {} should be present after reopen",
                 p
             );
-            let expected: Vec<u8> = (0..64).map(|i| (p as u8 + i) as u8).collect();
+            let expected: Vec<u8> = (0..64).map(|i| (p as u8 + i)).collect();
             let mut buf = vec![0u8; 64];
             cache.read_page(p, &mut buf).unwrap();
             assert_eq!(buf, expected, "page {} content mismatch after reopen", p);
@@ -2560,7 +2560,7 @@ fn test_clear_pages_at_or_above() {
     let dir = TempDir::new().unwrap();
     let cache = DiskCache::new(dir.path(), 3600, 4, 2, 64, 16, None, Vec::new()).unwrap();
     for p in 0..16u64 {
-        cache.write_page(p, &vec![1u8; 64]).unwrap();
+        cache.write_page(p, &[1u8; 64]).unwrap();
     }
     cache.clear_pages_at_or_above(10);
     for p in 0..10u64 {

--- a/src/tiered/test_encoding.rs
+++ b/src/tiered/test_encoding.rs
@@ -211,7 +211,7 @@ fn test_page_type_detection() {
         let type_byte = if page_num == 0 {
             buf.get(100)
         } else {
-            buf.get(0)
+            buf.first()
         };
         matches!(type_byte, Some(&0x05) | Some(&0x02))
     };
@@ -233,7 +233,7 @@ fn test_page_type_page_zero_offset_100() {
         let type_byte = if page_num == 0 {
             buf.get(100)
         } else {
-            buf.get(0)
+            buf.first()
         };
         matches!(type_byte, Some(&0x05) | Some(&0x02))
     };

--- a/src/tiered/test_flush.rs
+++ b/src/tiered/test_flush.rs
@@ -51,12 +51,12 @@ fn test_local_checkpoint_interior_page_detection() {
     // B-tree interior index page (type 0x02) — not page 0
     let mut interior_index = vec![0u8; page_size];
     interior_index[0] = 0x02;
-    assert_eq!(interior_index.get(0), Some(&0x02));
+    assert_eq!(interior_index.first(), Some(&0x02));
 
     // B-tree interior table page (type 0x05) — not page 0
     let mut interior_table = vec![0u8; page_size];
     interior_table[0] = 0x05;
-    assert_eq!(interior_table.get(0), Some(&0x05));
+    assert_eq!(interior_table.first(), Some(&0x05));
 
     // Page 0: type byte at offset 100 (after SQLite header)
     let mut page0 = vec![0u8; page_size];
@@ -103,8 +103,8 @@ fn test_override_threshold_boundary() {
     // When dirty_frames >= threshold: full rewrite
     let threshold = 4u32;
     assert!(3 < threshold); // override
-    assert!(!(4 < threshold)); // full rewrite
-    assert!(!(5 < threshold)); // full rewrite
+    assert!((4 >= threshold)); // full rewrite
+    assert!((5 >= threshold)); // full rewrite
 }
 
 #[test]

--- a/src/tiered/test_local_vfs.rs
+++ b/src/tiered/test_local_vfs.rs
@@ -2616,13 +2616,13 @@ fn test_settings_set_per_connection_isolation() {
         .expect("reg B");
 
     let conn_a =
-        rusqlite::Connection::open(&format!("file:a.db?vfs={}", vfs_a_name)).expect("open A");
+        rusqlite::Connection::open(format!("file:a.db?vfs={}", vfs_a_name)).expect("open A");
     conn_a
         .execute_batch("CREATE TABLE a (id INTEGER); INSERT INTO a VALUES (1);")
         .unwrap();
 
     let conn_b =
-        rusqlite::Connection::open(&format!("file:b.db?vfs={}", vfs_b_name)).expect("open B");
+        rusqlite::Connection::open(format!("file:b.db?vfs={}", vfs_b_name)).expect("open B");
     conn_b
         .execute_batch("CREATE TABLE b (id INTEGER); INSERT INTO b VALUES (2);")
         .unwrap();

--- a/src/tiered/test_prefetch.rs
+++ b/src/tiered/test_prefetch.rs
@@ -275,7 +275,7 @@ fn test_btree_groups_overwrite_when_group_in_multiple_btrees() {
 #[test]
 fn test_fraction_prefetch_first_miss_33_percent() {
     // With hops=[0.33, 0.33] and consecutive_misses=1, prefetch 33% of siblings
-    let hops = vec![0.33f32, 0.33];
+    let hops = [0.33f32, 0.33];
     let hop_idx = 0usize; // consecutive_misses=1, so hop_idx=0
     let fraction = hops[hop_idx];
     // 10 eligible siblings -> ceil(10 * 0.33) = 4
@@ -286,7 +286,7 @@ fn test_fraction_prefetch_first_miss_33_percent() {
 
 #[test]
 fn test_fraction_prefetch_second_miss_66_percent() {
-    let hops = vec![0.33f32, 0.33];
+    let hops = [0.33f32, 0.33];
     let hop_idx = 1usize; // consecutive_misses=2
     let fraction = hops[hop_idx];
     let eligible = 10;
@@ -297,13 +297,9 @@ fn test_fraction_prefetch_second_miss_66_percent() {
 
 #[test]
 fn test_fraction_prefetch_third_miss_all() {
-    let hops = vec![0.33f32, 0.33];
+    let hops = [0.33f32, 0.33];
     let hop_idx = 2usize; // consecutive_misses=3, beyond hops.len()
-    let fraction = if hop_idx < hops.len() {
-        hops[hop_idx]
-    } else {
-        1.0
-    };
+    let fraction = hops.get(hop_idx).copied().unwrap_or(1.0);
     assert_eq!(fraction, 1.0);
     let eligible = 10;
     let max_submit = ((eligible as f32) * fraction).ceil() as usize;
@@ -313,7 +309,7 @@ fn test_fraction_prefetch_third_miss_all() {
 #[test]
 fn test_fraction_prefetch_single_sibling() {
     // With only 1 eligible sibling, even 33% rounds up to 1
-    let hops = vec![0.33f32, 0.33];
+    let hops = [0.33f32, 0.33];
     let fraction = hops[0];
     let eligible = 1;
     let max_submit = ((eligible as f32) * fraction).ceil() as usize;
@@ -323,7 +319,7 @@ fn test_fraction_prefetch_single_sibling() {
 #[test]
 fn test_fraction_prefetch_zero_eligible() {
     // All siblings already fetching/present -> 0 eligible -> 0 to submit
-    let hops = vec![0.33f32, 0.33];
+    let hops = [0.33f32, 0.33];
     let fraction = hops[0];
     let eligible = 0;
     let max_submit = ((eligible as f32) * fraction).ceil() as usize;

--- a/src/tiered/test_query_plan.rs
+++ b/src/tiered/test_query_plan.rs
@@ -85,7 +85,7 @@ fn test_parse_ignores_non_scan_search() {
 USE TEMP B-TREE FOR ORDER BY
 COMPOUND SUBQUERY 1";
     let result = parse_eqp_output(eqp);
-    assert_eq!(result.is_empty(), true);
+    assert!(result.is_empty());
 }
 
 #[test]

--- a/src/tiered/test_rotation.rs
+++ b/src/tiered/test_rotation.rs
@@ -954,7 +954,7 @@ fn test_write_pages_scattered_data_integrity() {
     let page_nums = vec![3u64, 0, 7, 15];
     let mut data = Vec::with_capacity(4 * 64);
     for (i, &pnum) in page_nums.iter().enumerate() {
-        data.extend(std::iter::repeat(((pnum + 1) as u8) * 10 + i as u8).take(64));
+        data.extend(std::iter::repeat_n(((pnum + 1) as u8) * 10 + i as u8, 64));
     }
     cache
         .write_pages_scattered(&page_nums, &data, 0, 0)
@@ -1310,7 +1310,7 @@ fn test_write_pages_scattered_sparse_page_distribution() {
     let page_nums = vec![10u64, 500, 1000, 3999];
     let mut data = Vec::with_capacity(4 * 64);
     for &pnum in &page_nums {
-        data.extend(std::iter::repeat((pnum % 256) as u8).take(64));
+        data.extend(std::iter::repeat_n((pnum % 256) as u8, 64));
     }
     cache
         .write_pages_scattered(&page_nums, &data, 0, 0)

--- a/src/tiered/vfs.rs
+++ b/src/tiered/vfs.rs
@@ -95,7 +95,7 @@ impl TurboliteVfs {
             .worker_threads(2)
             .enable_all()
             .build()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("build tokio rt: {e}")))?;
+            .map_err(|e| io::Error::other(format!("build tokio rt: {e}")))?;
         let runtime = owned.handle().clone();
         config.apply_legacy_flat_fields();
 
@@ -113,9 +113,7 @@ impl TurboliteVfs {
                 .block_on(async {
                     hadb_storage_s3::S3Storage::from_env(bucket, endpoint.as_deref()).await
                 })
-                .map_err(|e| {
-                    io::Error::new(io::ErrorKind::Other, format!("create S3 backend: {e}"))
-                })?
+                .map_err(|e| io::Error::other(format!("create S3 backend: {e}")))?
                 .with_prefix(prefix);
             let storage: Arc<dyn StorageBackend> = Arc::new(storage);
             #[cfg(feature = "bundled-sqlite")]
@@ -759,7 +757,7 @@ impl TurboliteVfs {
                 }
             }
             processed += 1;
-            if processed % 20 == 0 || processed == total_pg {
+            if processed.is_multiple_of(20) || processed == total_pg {
                 eprintln!("  decoded {}/{} page groups", processed, total_pg);
             }
         }
@@ -1484,6 +1482,7 @@ impl TurboliteVfs {
             }
             FsOpenOptions::new()
                 .create(true)
+                .truncate(false)
                 .write(true)
                 .open(&lock_path)?;
 
@@ -1504,6 +1503,7 @@ impl TurboliteVfs {
                 }
                 let _ = FsOpenOptions::new()
                     .create(true)
+                    .truncate(false)
                     .write(true)
                     .open(&wal_path);
             }
@@ -1564,6 +1564,7 @@ impl TurboliteVfs {
                 .read(true)
                 .write(true)
                 .create(true)
+                .truncate(false)
                 .open(&path)?;
             Ok(TurboliteHandle::new_passthrough(
                 file,

--- a/tests/concurrent_test.rs
+++ b/tests/concurrent_test.rs
@@ -2,7 +2,7 @@ use rusqlite::{Connection, OpenFlags};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use turbolite::tiered::{TurboliteConfig, TurboliteVfs};
 
 #[test]

--- a/tests/config_set_auto_install.rs
+++ b/tests/config_set_auto_install.rs
@@ -30,7 +30,7 @@ fn unique_name(prefix: &str) -> String {
 /// courtesy of the auto-extension hook.
 fn open_bare(vfs_name: &str, db_file: &str) -> Connection {
     let conn = Connection::open_with_flags_and_vfs(
-        &format!("file:{}?vfs={}", db_file, vfs_name),
+        format!("file:{}?vfs={}", db_file, vfs_name),
         OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE,
         vfs_name,
     )

--- a/tests/config_set_per_handle.rs
+++ b/tests/config_set_per_handle.rs
@@ -26,7 +26,7 @@ fn unique_name(prefix: &str) -> String {
 
 fn open_connection(vfs_name: &str, db_file: &str) -> Connection {
     let conn = Connection::open_with_flags_and_vfs(
-        &format!("file:{}?vfs={}", db_file, vfs_name),
+        format!("file:{}?vfs={}", db_file, vfs_name),
         OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE,
         vfs_name,
     )

--- a/tests/config_set_process_global_check.rs
+++ b/tests/config_set_process_global_check.rs
@@ -36,7 +36,7 @@ fn plain_connection_does_not_inherit_scalar_from_alive_turbolite_handle() {
 
     // Turbolite connection stays alive — its queue is on the thread-local stack.
     let tlite = Connection::open_with_flags_and_vfs(
-        &format!("file:{}/tlite.db?vfs={}", tmp.path().display(), vfs_name),
+        format!("file:{}/tlite.db?vfs={}", tmp.path().display(), vfs_name),
         OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE,
         &vfs_name,
     )

--- a/tests/property_manifest.rs
+++ b/tests/property_manifest.rs
@@ -1,5 +1,4 @@
 use proptest::prelude::*;
-use rmp_serde;
 use std::collections::HashMap;
 use turbolite::tiered::{FrameEntry, GroupingStrategy, Manifest};
 

--- a/tests/property_page_groups.rs
+++ b/tests/property_page_groups.rs
@@ -43,7 +43,7 @@ fn compute_total_groups(page_count: u64, ppg: u32) -> u64 {
     if ppg == 0 || page_count == 0 {
         return 0;
     }
-    (page_count + ppg as u64 - 1) / ppg as u64
+    page_count.div_ceil(ppg as u64)
 }
 
 proptest! {

--- a/turbolite-ffi/src/ext.rs
+++ b/turbolite-ffi/src/ext.rs
@@ -67,6 +67,10 @@ extern "C" {
 /// The implementation lives in the C shim so it can use SQLite's extension
 /// API-table macros, but the exported symbol is Rust-owned. That keeps the
 /// cdylib export behavior consistent across macOS and Linux.
+///
+/// # Safety
+/// Called by SQLite during extension load. `db`, `pz_err_msg`, and `api` must
+/// be the valid pointers SQLite passes to an extension entry point.
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_turbolite_init(
     db: *mut c_void,
@@ -126,25 +130,13 @@ struct StorageCounters {
 }
 
 #[cfg(feature = "cli-s3")]
+#[derive(Default)]
 struct CounterBaselines {
     counters: Option<std::sync::Arc<StorageCounters>>,
     base_gets: u64,
     base_get_bytes: u64,
     base_puts: u64,
     base_put_bytes: u64,
-}
-
-#[cfg(feature = "cli-s3")]
-impl Default for CounterBaselines {
-    fn default() -> Self {
-        Self {
-            counters: None,
-            base_gets: 0,
-            base_get_bytes: 0,
-            base_puts: 0,
-            base_put_bytes: 0,
-        }
-    }
 }
 
 #[cfg(feature = "cli-s3")]
@@ -406,7 +398,7 @@ fn register_tiered() -> Result<(), std::io::Error> {
                 .await
                 .map(|storage| storage.with_prefix(prefix))
         })
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
     let backend: Arc<dyn hadb_storage::StorageBackend> = Arc::new(backend);
     let (counting_backend, counters_handle) = CountingStorageBackend::new(backend);
     let backend: Arc<dyn hadb_storage::StorageBackend> = Arc::new(counting_backend);
@@ -428,6 +420,10 @@ fn register_tiered() -> Result<(), std::io::Error> {
             ..TurboliteConfig::from_env()
         },
     };
+    // Legacy process-global shim; new VFS instances derive checkpoint mode from
+    // config.cache.checkpoint_mode and ignore this flag. Kept as-is to preserve
+    // existing behavior; allow the deprecation rather than change semantics.
+    #[allow(deprecated)]
     turbolite::tiered::set_local_checkpoint_only(
         std::env::var("TURBOLITE_LOCAL_THEN_FLUSH")
             .map(|v| !matches!(v.as_str(), "false" | "0"))
@@ -580,6 +576,9 @@ pub extern "C" fn turbolite_bench_flush_to_storage() -> i32 {
 
 /// Evict cached data for named trees. tree_names is a comma-separated C string.
 /// Returns number of groups evicted, or -1 if no tiered VFS.
+///
+/// # Safety
+/// `tree_names` must be NULL or a valid, NUL-terminated C string.
 #[cfg(feature = "cli-s3")]
 #[no_mangle]
 pub unsafe extern "C" fn turbolite_evict_tree(tree_names: *const std::os::raw::c_char) -> i32 {
@@ -635,6 +634,10 @@ pub extern "C" fn turbolite_cache_info() -> *const std::os::raw::c_char {
 /// Warm cache for a planned query. Runs EQP to extract trees, submits groups to prefetch.
 /// Returns JSON C string with trees warmed and groups submitted. Null if no tiered VFS.
 /// db must be a valid sqlite3 handle, sql must be a valid C string.
+///
+/// # Safety
+/// `db` must be a valid `sqlite3*` handle. `sql` must be NULL or a valid,
+/// NUL-terminated C string.
 #[cfg(feature = "cli-s3")]
 #[no_mangle]
 pub unsafe extern "C" fn turbolite_warm(
@@ -681,6 +684,10 @@ pub unsafe extern "C" fn turbolite_warm(
 
 /// Evict cached data for trees referenced by a SQL query. Runs EQP, extracts
 /// tree names, evicts their groups. Returns groups evicted, or -1 if no VFS.
+///
+/// # Safety
+/// `db` must be a valid `sqlite3*` handle. `sql` must be NULL or a valid,
+/// NUL-terminated C string.
 #[cfg(feature = "cli-s3")]
 #[no_mangle]
 pub unsafe extern "C" fn turbolite_evict_query(
@@ -716,6 +723,9 @@ pub unsafe extern "C" fn turbolite_evict_query(
 
 /// Evict cached sub-chunks by tier. Accepts "data", "index", or "all".
 /// Returns number of sub-chunks evicted, or -1 if no tiered VFS.
+///
+/// # Safety
+/// `tier` must be NULL or a valid, NUL-terminated C string.
 #[cfg(feature = "cli-s3")]
 #[no_mangle]
 pub unsafe extern "C" fn turbolite_evict(tier: *const std::os::raw::c_char) -> i32 {

--- a/turbolite-ffi/src/install.rs
+++ b/turbolite-ffi/src/install.rs
@@ -190,7 +190,7 @@ pub unsafe extern "C" fn turbolite_install_config_functions(db: *mut sqlite3) ->
         // Force xOpen on the main-db file so THIS connection's handle
         // queue is top-of-stack on the thread-local. `PRAGMA schema_version`
         // reads page 1 which is enough to trigger the VFS open.
-        let pragma = CStr::from_bytes_with_nul(b"PRAGMA schema_version\0").expect("static cstring");
+        let pragma = c"PRAGMA schema_version";
         let mut err_msg: *mut c_char = std::ptr::null_mut();
         let rc = sqlite3_exec(
             db,
@@ -211,7 +211,7 @@ pub unsafe extern "C" fn turbolite_install_config_functions(db: *mut sqlite3) ->
             return SQLITE_MISUSE;
         }
 
-        let fn_name = CStr::from_bytes_with_nul(b"turbolite_config_set\0").expect("static cstring");
+        let fn_name = c"turbolite_config_set";
         sqlite3_create_function_v2(
             db,
             fn_name.as_ptr(),
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn turbolite_install_config_functions(db: *mut sqlite3) ->
 /// `vfs=<some name passed to turbolite::tiered::register>`.
 unsafe fn connection_uses_turbolite_vfs(db: *mut sqlite3) -> bool {
     let mut vfs_ptr: *mut sqlite3_vfs_prefix = std::ptr::null_mut();
-    let main = b"main\0".as_ptr() as *const c_char;
+    let main = c"main".as_ptr() as *const c_char;
     let rc = sqlite3_file_control(
         db,
         main,


### PR DESCRIPTION
`cargo clippy` reported ~109 warnings — it had never been enforced on the ffi crate. This drives the **lib, ffi-default, and ffi-loadable-extension** builds all to **0 warnings**, with no behavior change.

### What changed
- **Machine-applicable fixes** (`clippy --fix`): `io::Error::other`, `div_ceil`, slice `.first()`, derivable `Default` impls, `sort_by_key`, `c"..."` C-string literals, redundant casts/locals, needless range loops, etc.
- **`suspicious_open_options`** (9 sites): added explicit `.truncate(false)`. This makes the current default behavior intentional without changing it — **never `.truncate(true)`** (that would wipe file contents).
- **`too_many_arguments`**: allowed crate-wide with a rationale comment — the tiered storage pipeline threads many params through flush/compact/prefetch by design; bundling them into structs is a separate refactor.
- **`missing_safety_doc`**: added `# Safety` sections to the `unsafe extern "C"` FFI entry points.
- **Deprecated `SyncMode::S3Primary` / `set_local_checkpoint_only`**: scoped `#[allow(deprecated)]` with comments — these are kept for back-compat; migrating them would change config semantics, so behavior is preserved.

### Behavior preservation
Every change is either a comment (`# Safety` docs), a semantically-identical rewrite (`io::Error::other`, `div_ceil`, derive), an explicit no-op (`.truncate(false)` = the existing default), or a scoped `#[allow]`. No logic changes.

### Verification
- `cargo clippy` — **0 warnings** in all three modes (lib, ffi default, ffi loadable-extension)
- lib suite: **568 passed, 0 failed**
- loadable extension (Python): **27/27**

🤖 Generated with [Claude Code](https://claude.com/claude-code)