### PR TITLE
Add replay cursor Quint contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ packages/python/turbolite/turbolite
 
 # Proptest regression minimization files (generated during failing runs)
 *.proptest-regressions
+
+# Quint / Apalache model-checker output
+_apalache-out/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,9 +106,8 @@ rmp-serde = "1.3.1"
 # Canonical encoding for the Turbolite manifest wire format. ciborium
 # produces RFC 8949 §4.2 deterministically-encoded CBOR when used with
 # `ciborium::ser::into_writer` on a serde-derived value whose field
-# order is fixed and whose integers use smallest-length encoding — the
-# property phase 004 relies on for BLAKE3-hash stability across
-# implementations.
+# order is fixed and whose integers use smallest-length encoding — needed
+# for BLAKE3 hash stability across implementations.
 ciborium = "0.2"
 # Cryptographic hash for the chain link primitive. BLAKE3 chosen for
 # canonical-byte hashing of manifest and delta objects (replay cursor

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,20 @@ FFI_DIR := turbolite-ffi
 # Features forwarded to cargo.
 FEATURES ?= zstd
 
+QUINT ?= npx -y @informalsystems/quint@0.32.0
+OPENJDK_PREFIX ?= $(shell brew --prefix openjdk 2>/dev/null)
+JAVA_PATH_PREFIX := $(if $(OPENJDK_PREFIX),$(OPENJDK_PREFIX)/bin:)
+SPEC_NEGATIVE_STEPS := \
+	badWrongEpochStep \
+	badWrongWriterStep \
+	badSkippedSeqStep \
+	badPrevChecksumStep \
+	badEquivocationStep \
+	badChecksumCollisionStep \
+	badStaleWriterAfterPromotionStep \
+	badPromotionCursorStep \
+	badPromotionPageCountStep
+
 # ── FFI build passthrough ─────────────────────────────────────────
 
 .PHONY: lib lib-bundled ext ext-local header
@@ -56,6 +70,83 @@ test: ## Run all tests (Rust unit + FFI)
 .PHONY: test-all
 test-all: ## Run all tests including tiered/S3
 	cargo test --features zstd,tiered,bundled-sqlite
+
+.PHONY: specs-typecheck
+specs-typecheck: ## Typecheck Quint substrate specs
+	$(QUINT) typecheck specs/cursor_chain.qnt
+	$(QUINT) typecheck specs/cursor_chain_liveness.qnt
+
+.PHONY: specs
+specs: specs-typecheck ## Run Quint substrate specs (typecheck + simulator invariants)
+	$(QUINT) run specs/cursor_chain.qnt \
+		--max-samples=200 --max-steps=8 --invariants=safety
+
+.PHONY: specs-progress
+specs-progress: specs-typecheck ## Run deterministic Quint progress scenario
+	$(QUINT) run specs/cursor_chain.qnt \
+		--step=progressStep --max-samples=1 --max-steps=4 \
+		--invariants=safety boundedProgress
+
+.PHONY: specs-negative
+specs-negative: specs-typecheck ## Run Quint specs that are expected to violate safety
+	@for step in $(SPEC_NEGATIVE_STEPS); do \
+		out=$$(mktemp "$${TMPDIR:-/tmp}/turbolite-quint-$$step.XXXXXX") || exit 1; \
+		echo "expecting safety violation: $$step"; \
+		if $(QUINT) run specs/cursor_chain.qnt \
+			--max-samples=20 --max-steps=2 --step=$$step \
+			--invariants=safety --verbosity=0 \
+			>"$$out" 2>&1; then \
+			cat "$$out"; \
+			rm -f "$$out"; \
+			echo "expected $$step to violate safety"; \
+			exit 1; \
+		elif ! grep -q "Invariant violated" "$$out"; then \
+			cat "$$out"; \
+			rm -f "$$out"; \
+			echo "expected $$step to fail by violating safety"; \
+			exit 1; \
+		fi; \
+		rm -f "$$out"; \
+	done
+
+.PHONY: specs-all
+specs-all: specs specs-progress specs-negative specs-rust specs-verify specs-liveness specs-liveness-negative ## Run all local spec checks
+
+.PHONY: specs-verify
+specs-verify: specs-typecheck ## Run Quint bounded model checker (requires Java)
+	PATH="$(JAVA_PATH_PREFIX)$$PATH" $(QUINT) verify specs/cursor_chain.qnt \
+		--max-steps=8 --invariants=safety
+	PATH="$(JAVA_PATH_PREFIX)$$PATH" $(QUINT) verify specs/cursor_chain.qnt \
+		--step=progressStep --max-steps=4 --invariants=safety boundedProgress
+
+.PHONY: specs-rust
+specs-rust: ## Run Rust tests that bridge the Quint substrate contract
+	cargo test --features zstd,bundled-sqlite replay_cursor_contract
+
+.PHONY: specs-liveness
+specs-liveness: specs-typecheck ## Run TLC temporal liveness check under explicit fairness
+	PATH="$(JAVA_PATH_PREFIX)$$PATH" $(QUINT) verify specs/cursor_chain_liveness.qnt \
+		--backend=tlc --max-steps=8 --invariants=safety \
+		--temporal=fairStablePrefixProgress
+
+.PHONY: specs-liveness-negative
+specs-liveness-negative: specs-typecheck ## Run temporal property expected to fail without fairness
+	@out=$$(mktemp "$${TMPDIR:-/tmp}/turbolite-quint-badUnfairPollingProgress.XXXXXX") || exit 1; \
+	if PATH="$(JAVA_PATH_PREFIX)$$PATH" $(QUINT) verify specs/cursor_chain_liveness.qnt \
+		--backend=tlc --max-steps=8 --invariants=safety \
+		--temporal=badUnfairPollingProgress \
+		>"$$out" 2>&1; then \
+		cat "$$out"; \
+		rm -f "$$out"; \
+		echo "expected badUnfairPollingProgress to violate temporal progress"; \
+		exit 1; \
+	elif ! grep -q "Temporal properties were violated" "$$out"; then \
+		cat "$$out"; \
+		rm -f "$$out"; \
+		echo "expected badUnfairPollingProgress to fail by violating temporal progress"; \
+		exit 1; \
+	fi; \
+	rm -f "$$out"
 
 .PHONY: test-ext test-ffi test-ffi-tiered test-ffi-python test-ffi-c test-ffi-go test-ffi-node
 test-ext test-ffi test-ffi-tiered test-ffi-python test-ffi-c test-ffi-go test-ffi-node: ## FFI / loadable-ext tests live in turbolite-ffi now

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,229 @@
+# Turbolite Quint Specs
+
+These specs model small protocol contracts at the Turbolite/HADB
+boundary. They are not part of the normal Rust build, and they do not
+model SQLite page contents, compression, encryption, object-store
+consistency, or prefetch scheduling.
+
+The first safety spec is `cursor_chain.qnt`. It models the replay cursor
+base/delta contract: ordered delta application, writer and lease fencing,
+chain anchors, promotion, and fatal ambiguity handling.
+
+## Tools
+
+Use Quint 0.32.0 through `npx`:
+
+```sh
+npx -y @informalsystems/quint@0.32.0 --version
+```
+
+`quint run` and `quint typecheck` work without Java. `quint verify`
+uses Apalache by default for bounded safety checks and TLC for the
+temporal liveness check. Both verifier backends require a local Java
+runtime. On macOS, Homebrew OpenJDK is enough:
+
+```sh
+brew install openjdk
+```
+
+## Local Checks
+
+From the Turbolite repo root:
+
+```sh
+make specs
+```
+
+This runs:
+
+```sh
+npx -y @informalsystems/quint@0.32.0 typecheck specs/cursor_chain.qnt
+npx -y @informalsystems/quint@0.32.0 typecheck specs/cursor_chain_liveness.qnt
+npx -y @informalsystems/quint@0.32.0 run specs/cursor_chain.qnt \
+  --max-samples=200 --max-steps=8 --invariants=safety
+```
+
+Expected result: typecheck succeeds, simulator runs without invariant
+violations.
+
+The progress check is deterministic:
+
+```sh
+make specs-progress
+```
+
+This seeds a three-delta valid prefix and uses the `progressStep`
+relation. It is a bounded no-stutter scenario, not a proof of general
+fair liveness for the normal `step` relation. `boundedProgress`
+requires the follower to apply all three seeded deltas within the
+bound while preserving `safety`.
+
+To run the positive safety simulation, deterministic progress scenario,
+expected-failure counterexamples, Rust bridge tests, bounded model
+checker, and TLC liveness checks:
+
+```sh
+make specs-all
+```
+
+This is the full local verification target, not a quick smoke check. It
+requires Java for Apalache/TLC and intentionally exercises the Rust replay
+cursor bridge after real replay finalization.
+
+## Model Checker
+
+When Java is available, run the bounded model checker:
+
+```sh
+make specs-verify
+```
+
+This runs:
+
+```sh
+PATH="$(brew --prefix openjdk)/bin:$PATH" \
+  npx -y @informalsystems/quint@0.32.0 verify specs/cursor_chain.qnt \
+    --max-steps=8 --invariants=safety
+PATH="$(brew --prefix openjdk)/bin:$PATH" \
+  npx -y @informalsystems/quint@0.32.0 verify specs/cursor_chain.qnt \
+    --step=progressStep --max-steps=4 --invariants=safety boundedProgress
+```
+
+Expected result: verification succeeds over the bounded state space.
+
+## Temporal Liveness
+
+`cursor_chain_liveness.qnt` is a separate, smaller temporal model. It
+does not claim object-store, root-publish, writer-election, or full
+promotion liveness. Its environment assumptions are explicit:
+
+- the root/lease fence is stable,
+- a three-delta valid prefix remains visible,
+- no fatal equivocation/collision is present,
+- the follower keeps polling,
+- `applyNext` is weakly fair when it stays enabled.
+
+Run the positive temporal check with TLC:
+
+```sh
+make specs-liveness
+```
+
+This checks:
+
+```sh
+npx -y @informalsystems/quint@0.32.0 verify specs/cursor_chain_liveness.qnt \
+  --backend=tlc --max-steps=8 --invariants=safety \
+  --temporal=fairStablePrefixProgress
+```
+
+Expected result: TLC checks the complete small state space and finds no
+temporal violation. The property is: under weak fairness of `applyNext`,
+a stable available prefix eventually leads to the follower catching up.
+
+The companion negative check proves the fairness assumption is doing real
+work:
+
+```sh
+make specs-liveness-negative
+```
+
+Expected result: `badUnfairPollingProgress` violates temporal progress,
+because without fairness the follower can poll/stutter forever.
+
+## Negative Counterexamples
+
+The spec contains intentionally bad step actions. They should all
+violate `safety` and produce short counterexamples:
+
+```sh
+make specs-negative
+```
+
+Expected result: each named bad step reports an expected invariant
+violation:
+
+- `badWrongEpochStep`
+- `badWrongWriterStep`
+- `badSkippedSeqStep`
+- `badPrevChecksumStep`
+- `badEquivocationStep`
+- `badChecksumCollisionStep`
+- `badStaleWriterAfterPromotionStep`
+- `badPromotionCursorStep`
+- `badPromotionPageCountStep`
+
+`badChecksumCollisionStep` uses the spec's compact
+`payloadFingerprint` field to stand in for the full production delta
+envelope: changed page bytes, commit boundary, idempotency key, page
+counts, sequence, writer, epoch, and chain link. The model therefore
+checks the intended rule, "one checksum cannot name two different
+payload envelopes," without expanding page bytes in Quint.
+
+For a full counterexample trace, run an individual step without
+`--verbosity=0`, for example:
+
+```sh
+npx -y @informalsystems/quint@0.32.0 run specs/cursor_chain.qnt \
+  --max-samples=20 --max-steps=2 --step=badWrongEpochStep \
+  --invariants=safety
+```
+
+## Rust Mapping
+
+`cursor_chain.qnt` models these Rust surfaces:
+
+- `src/tiered/manifest.rs`
+  - `ReplayCursor`
+  - `Manifest::writer_id`
+- `src/tiered/wire.rs`
+  - canonical manifest bytes
+  - `base_anchor_checksum`
+- `src/tiered/vfs.rs`
+  - `manifest_bytes_with_replay_cursor_anchor`
+  - `update_replay_cursor`
+  - `publish_replayed_base_with_replay_cursor_anchor`
+- `src/tiered/replay.rs`
+  - direct page replay lifecycle
+
+The modeled Rust-facing properties have a matching Rust bridge target:
+
+```sh
+make specs-rust
+```
+
+This runs `cargo test --features zstd,bundled-sqlite replay_cursor_contract`.
+Those tests bridge the first Quint model to production Rust surfaces:
+
+- `replay_cursor_contract_manifest_bytes_stamps_cursor_writer_and_anchor`
+  checks the VFS publisher path stamps seq/epoch/writer and the base
+  chain anchor.
+- `replay_cursor_contract_begin_replay_uses_installed_cursor_floor`
+  checks the default replay handle resumes after the installed cursor,
+  not behind it.
+- `replay_cursor_contract_manifest_bytes_rejects_invalid_cursor_inputs`
+  checks anchored cursor publication rejects zero epochs, blank writers, and
+  backward cursor movement.
+- `replay_cursor_contract_update_replay_cursor_preserves_base_shape_and_writer`
+  checks follower cursor advancement does not rewrite the base shape.
+- `replay_cursor_contract_update_replay_cursor_rejects_malformed_or_backward_cursor`
+  checks follower cursor advancement rejects malformed anchors, missing
+  writer identity, and backward movement.
+- `replay_cursor_contract_publish_replayed_base_stamps_final_cursor_anchor`
+  checks promotion stamps seq/epoch/writer and recomputes the anchor
+  over the final published base.
+- `replay_cursor_contract_publish_replayed_base_after_replay_carries_post_replay_state`
+  checks the anchored publisher after a real replay finalize, including
+  non-regressing legacy change counter, exact replay cursor, writer, and
+  recomputed base anchor.
+- `replay_cursor_contract_base_anchor_binds_cursor_epoch_and_writer`
+  checks the wire hash domain includes seq, lease epoch, and writer.
+- `replay_cursor_contract_recovery_plan_applies_contiguous_prefix_and_page_counts`
+  checks a three-delta prefix advances contiguous sequence and
+  grow/shrink page counts.
+- `replay_cursor_contract_recovery_plan_rejects_stale_epoch_candidate`
+  checks stale-epoch candidates do not satisfy the root fence.
+
+Existing Sashimono tests in `src/tiered/sashimono.rs` also cover wrong
+writer, missing gaps, duplicate same-seq candidates, wrong base page
+count, page-size mismatch, and corrupt/torn delta payloads.

--- a/specs/cursor_chain.qnt
+++ b/specs/cursor_chain.qnt
@@ -1,0 +1,777 @@
+module cursor_chain {
+  type Writer = str
+  type Checksum = str
+
+  type Base = {
+    seq: int,
+    epoch: int,
+    writer: Writer,
+    checksum: Checksum,
+    endPageCount: int,
+  }
+
+  type Delta = {
+    seq: int,
+    epoch: int,
+    writer: Writer,
+    prevChecksum: Checksum,
+    checksum: Checksum,
+    payloadFingerprint: Checksum,
+    endPageCount: int,
+  }
+
+  pure val writers: Set[Writer] = Set("A", "B")
+  pure val epochs: Set[int] = Set(0, 1)
+  pure val seqs: Set[int] = Set(1, 2, 3)
+  pure val pageCounts: Set[int] = Set(0, 1, 2)
+  pure val checksums: Set[Checksum] = Set("base0", "base1", "d1", "d2", "d3", "bad")
+  pure val payloadFingerprints: Set[Checksum] = Set("payload", "otherPayload")
+
+  pure val initialBase: Base = {
+    seq: 0,
+    epoch: 0,
+    writer: "A",
+    checksum: "base0",
+    endPageCount: 0,
+  }
+
+  pure val promotedBaseChecksum: Checksum = "base1"
+
+  pure val progressDelta1: Delta = {
+    seq: 1,
+    epoch: 0,
+    writer: "A",
+    prevChecksum: "base0",
+    checksum: "d1",
+    payloadFingerprint: "p1",
+    endPageCount: 1,
+  }
+
+  pure val progressDelta2: Delta = {
+    seq: 2,
+    epoch: 0,
+    writer: "A",
+    prevChecksum: "d1",
+    checksum: "d2",
+    payloadFingerprint: "p2",
+    endPageCount: 2,
+  }
+
+  pure val progressDelta3: Delta = {
+    seq: 3,
+    epoch: 0,
+    writer: "A",
+    prevChecksum: "d2",
+    checksum: "d3",
+    payloadFingerprint: "p3",
+    endPageCount: 1,
+  }
+
+  pure val deltaUniverse: Set[Delta] =
+    tuples(seqs, epochs, writers, checksums, checksums, payloadFingerprints, pageCounts)
+      .map(((seq, epoch, writer, prevChecksum, checksum, payloadFingerprint, endPageCount)) => {
+        seq: seq,
+        epoch: epoch,
+        writer: writer,
+        prevChecksum: prevChecksum,
+        checksum: checksum,
+        payloadFingerprint: payloadFingerprint,
+        endPageCount: endPageCount,
+      })
+
+  var root: Base
+  var leaseEpoch: int
+  var leaseHolder: Writer
+  var deltas: Set[Delta]
+  var followerBaseSeq: int
+  var followerBaseChecksum: Checksum
+  var followerSeq: int
+  var followerEpoch: int
+  var followerWriter: Writer
+  var chainAnchor: Checksum
+  var pageCount: int
+  var applied: Set[Delta]
+  var fatal: bool
+  var promoted: bool
+  var promotedFromSeq: int
+  var promotedFromPageCount: int
+  var promotedFromApplied: Set[Delta]
+  var progressSeeded: bool
+  var progressTicks: int
+
+  action init = all {
+    root' = initialBase,
+    leaseEpoch' = 0,
+    leaseHolder' = "A",
+    deltas' = Set(),
+    followerBaseSeq' = initialBase.seq,
+    followerBaseChecksum' = initialBase.checksum,
+    followerSeq' = initialBase.seq,
+    followerEpoch' = initialBase.epoch,
+    followerWriter' = initialBase.writer,
+    chainAnchor' = initialBase.checksum,
+    pageCount' = initialBase.endPageCount,
+    applied' = Set(),
+    fatal' = false,
+    promoted' = false,
+    promotedFromSeq' = initialBase.seq,
+    promotedFromPageCount' = initialBase.endPageCount,
+    promotedFromApplied' = Set(),
+    progressSeeded' = false,
+    progressTicks' = 0,
+  }
+
+  pure def sameCandidateSlot(a: Delta, b: Delta): bool =
+    a.seq == b.seq and a.epoch == b.epoch and a.writer == b.writer
+
+  pure def divergentCandidate(a: Delta, b: Delta): bool =
+    sameCandidateSlot(a, b)
+      and (
+        a.prevChecksum != b.prevChecksum
+          or a.checksum != b.checksum
+          or a.payloadFingerprint != b.payloadFingerprint
+          or a.endPageCount != b.endPageCount
+      )
+
+  /// `checksum` abstracts BLAKE3 over the production delta envelope.
+  /// `payloadFingerprint` stands for compacted fields this model does not
+  /// expand, including changed page bytes, commit boundary, and idempotency key.
+  pure def samePayloadShape(a: Delta, b: Delta): bool =
+    a.seq == b.seq
+      and a.epoch == b.epoch
+      and a.writer == b.writer
+      and a.prevChecksum == b.prevChecksum
+      and a.payloadFingerprint == b.payloadFingerprint
+      and a.endPageCount == b.endPageCount
+
+  pure def hasEquivocation(candidates: Set[Delta]): bool =
+    candidates.exists(a => candidates.exists(b => divergentCandidate(a, b)))
+
+  pure def hasChecksumCollision(candidates: Set[Delta]): bool =
+    candidates.exists(a =>
+      candidates.exists(b =>
+        a.checksum == b.checksum and not(samePayloadShape(a, b))
+      )
+    )
+
+  pure def candidatesWellFormed(candidates: Set[Delta]): bool =
+    not(hasEquivocation(candidates)) and not(hasChecksumCollision(candidates))
+
+  action noStateChange = all {
+    root' = root,
+    leaseEpoch' = leaseEpoch,
+    leaseHolder' = leaseHolder,
+    deltas' = deltas,
+    followerBaseSeq' = followerBaseSeq,
+    followerBaseChecksum' = followerBaseChecksum,
+    followerSeq' = followerSeq,
+    followerEpoch' = followerEpoch,
+    followerWriter' = followerWriter,
+    chainAnchor' = chainAnchor,
+    pageCount' = pageCount,
+    applied' = applied,
+    fatal' = fatal,
+    promoted' = promoted,
+    promotedFromSeq' = promotedFromSeq,
+    promotedFromPageCount' = promotedFromPageCount,
+    promotedFromApplied' = promotedFromApplied,
+    progressSeeded' = progressSeeded,
+    progressTicks' = progressTicks,
+  }
+
+  action appendDelta = {
+    nondet d = oneOf(deltaUniverse)
+    all {
+      candidatesWellFormed(deltas.union(Set(d))),
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas.union(Set(d)),
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = followerSeq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = chainAnchor,
+      pageCount' = pageCount,
+      applied' = applied,
+      fatal' = fatal,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  action recordEquivocation = {
+    nondet a = oneOf(deltaUniverse)
+    nondet b = oneOf(deltaUniverse.filter(b => divergentCandidate(a, b)))
+    all {
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas.union(Set(a, b)),
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = followerSeq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = chainAnchor,
+      pageCount' = pageCount,
+      applied' = applied,
+      fatal' = true,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  action applyNext = {
+    nondet d = oneOf(deltas)
+    all {
+      not(fatal),
+      d.seq == followerSeq + 1,
+      d.epoch == followerEpoch,
+      d.writer == followerWriter,
+      d.prevChecksum == chainAnchor,
+
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas,
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = d.seq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = d.checksum,
+      pageCount' = d.endPageCount,
+      applied' = applied.union(Set(d)),
+      fatal' = fatal,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  action promote = {
+    nondet newWriter = oneOf(writers)
+    all {
+      not(fatal),
+      not(promoted),
+      root' = {
+        seq: followerSeq,
+        epoch: leaseEpoch + 1,
+        writer: newWriter,
+        checksum: promotedBaseChecksum,
+        endPageCount: pageCount,
+      },
+      leaseEpoch' = leaseEpoch + 1,
+      leaseHolder' = newWriter,
+      deltas' = deltas,
+      followerBaseSeq' = followerSeq,
+      followerBaseChecksum' = promotedBaseChecksum,
+      followerSeq' = followerSeq,
+      followerEpoch' = leaseEpoch + 1,
+      followerWriter' = newWriter,
+      chainAnchor' = promotedBaseChecksum,
+      pageCount' = pageCount,
+      applied' = Set(),
+      fatal' = fatal,
+      promoted' = true,
+      promotedFromSeq' = followerSeq,
+      promotedFromPageCount' = pageCount,
+      promotedFromApplied' = applied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  action step = any {
+    appendDelta,
+    recordEquivocation,
+    applyNext,
+    promote,
+    noStateChange,
+  }
+
+  action seedProgressChain = all {
+    not(progressSeeded),
+    not(fatal),
+    not(promoted),
+    root == initialBase,
+    followerSeq == initialBase.seq,
+    followerEpoch == initialBase.epoch,
+    followerWriter == initialBase.writer,
+    chainAnchor == initialBase.checksum,
+
+    root' = root,
+    leaseEpoch' = leaseEpoch,
+    leaseHolder' = leaseHolder,
+    deltas' = Set(progressDelta1, progressDelta2, progressDelta3),
+    followerBaseSeq' = followerBaseSeq,
+    followerBaseChecksum' = followerBaseChecksum,
+    followerSeq' = followerSeq,
+    followerEpoch' = followerEpoch,
+    followerWriter' = followerWriter,
+    chainAnchor' = chainAnchor,
+    pageCount' = pageCount,
+    applied' = applied,
+    fatal' = fatal,
+    promoted' = promoted,
+    promotedFromSeq' = promotedFromSeq,
+    promotedFromPageCount' = promotedFromPageCount,
+    promotedFromApplied' = promotedFromApplied,
+    progressSeeded' = true,
+    progressTicks' = 0,
+  }
+
+  action progressApplyNext = {
+    nondet d = oneOf(deltas.filter(d =>
+      d.seq == followerSeq + 1
+        and d.epoch == followerEpoch
+        and d.writer == followerWriter
+        and d.prevChecksum == chainAnchor
+    ))
+    all {
+      progressSeeded,
+      not(fatal),
+      followerSeq < 3,
+
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas,
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = d.seq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = d.checksum,
+      pageCount' = d.endPageCount,
+      applied' = applied.union(Set(d)),
+      fatal' = fatal,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks + 1,
+    }
+  }
+
+  action progressDone = all {
+    progressSeeded,
+    followerSeq == 3,
+
+    root' = root,
+    leaseEpoch' = leaseEpoch,
+    leaseHolder' = leaseHolder,
+    deltas' = deltas,
+    followerBaseSeq' = followerBaseSeq,
+    followerBaseChecksum' = followerBaseChecksum,
+    followerSeq' = followerSeq,
+    followerEpoch' = followerEpoch,
+    followerWriter' = followerWriter,
+    chainAnchor' = chainAnchor,
+    pageCount' = pageCount,
+    applied' = applied,
+    fatal' = fatal,
+    promoted' = promoted,
+    promotedFromSeq' = promotedFromSeq,
+    promotedFromPageCount' = promotedFromPageCount,
+    promotedFromApplied' = promotedFromApplied,
+    progressSeeded' = progressSeeded,
+    progressTicks' = progressTicks,
+  }
+
+  action progressStep = any {
+    seedProgressChain,
+    progressApplyNext,
+    progressDone,
+  }
+
+  def appliedHasSeq(seq: int): bool =
+    applied.exists(d => d.seq == seq)
+
+  def oneAppliedPerSeq: bool =
+    applied.forall(a => applied.forall(b => a.seq != b.seq or a == b))
+
+  def contiguousApplied: bool =
+    seqs.forall(seq =>
+      seq <= followerBaseSeq
+        or seq > followerSeq
+        or appliedHasSeq(seq)
+    )
+
+  def appliedMatchesFence: bool =
+    applied.forall(d => d.epoch == followerEpoch and d.writer == followerWriter)
+
+  def appliedChainsFromBase: bool =
+    applied.forall(d =>
+      if (d.seq == followerBaseSeq + 1) {
+        d.prevChecksum == followerBaseChecksum
+      } else {
+        applied.exists(prev =>
+          prev.seq == d.seq - 1 and d.prevChecksum == prev.checksum
+        )
+      }
+    )
+
+  def pageCountMatchesCursor: bool =
+    if (followerSeq == followerBaseSeq) {
+      pageCount == root.endPageCount
+    } else {
+      applied.exists(d => d.seq == followerSeq and pageCount == d.endPageCount)
+    }
+
+  def equivocationIsFatal: bool =
+    hasEquivocation(deltas) implies fatal
+
+  def checksumCollisionIsFatal: bool =
+    hasChecksumCollision(deltas) implies fatal
+
+  def rootMatchesLease: bool =
+    root.epoch == leaseEpoch and root.writer == leaseHolder
+
+  def followerBaseMatchesRoot: bool =
+    followerBaseSeq == root.seq and followerBaseChecksum == root.checksum
+
+  def promotedAppliedHasSeq(seq: int): bool =
+    promotedFromApplied.exists(d => d.seq == seq)
+
+  def promotedAppliedPrefixExact: bool =
+    promoted implies and {
+      root.seq == promotedFromSeq,
+      root.endPageCount == promotedFromPageCount,
+      seqs.forall(seq =>
+        seq <= initialBase.seq
+          or seq > promotedFromSeq
+          or promotedAppliedHasSeq(seq)
+      ),
+      promotedFromApplied.forall(d =>
+        d.seq > initialBase.seq
+          and d.seq <= promotedFromSeq
+          and d.epoch == initialBase.epoch
+          and d.writer == initialBase.writer
+      ),
+      if (promotedFromSeq == initialBase.seq) {
+        promotedFromPageCount == initialBase.endPageCount
+      } else {
+        promotedFromApplied.exists(d =>
+          d.seq == promotedFromSeq and d.endPageCount == promotedFromPageCount
+        )
+      },
+    }
+
+  def boundedProgress: bool =
+    not(progressSeeded) or progressTicks < 3 or fatal or followerSeq == 3
+
+  def safety: bool = and {
+    rootMatchesLease,
+    followerBaseMatchesRoot,
+    promotedAppliedPrefixExact,
+    followerSeq >= followerBaseSeq,
+    followerEpoch == leaseEpoch,
+    followerWriter == leaseHolder,
+    oneAppliedPerSeq,
+    contiguousApplied,
+    appliedMatchesFence,
+    appliedChainsFromBase,
+    pageCountMatchesCursor,
+    equivocationIsFatal,
+    checksumCollisionIsFatal,
+  }
+
+  /// Bad transition: applies a delta from the wrong epoch.
+  action badWrongEpochStep = {
+    nondet d = oneOf(deltaUniverse.filter(d =>
+      d.seq == followerSeq + 1
+        and d.epoch != followerEpoch
+        and d.writer == followerWriter
+        and d.prevChecksum == chainAnchor
+    ))
+    all {
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas.union(Set(d)),
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = d.seq,
+      followerEpoch' = d.epoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = d.checksum,
+      pageCount' = d.endPageCount,
+      applied' = applied.union(Set(d)),
+      fatal' = fatal,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  /// Bad transition: applies a delta from the wrong writer.
+  action badWrongWriterStep = {
+    nondet d = oneOf(deltaUniverse.filter(d =>
+      d.seq == followerSeq + 1
+        and d.epoch == followerEpoch
+        and d.writer != followerWriter
+        and d.prevChecksum == chainAnchor
+    ))
+    all {
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas.union(Set(d)),
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = d.seq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = d.writer,
+      chainAnchor' = d.checksum,
+      pageCount' = d.endPageCount,
+      applied' = applied.union(Set(d)),
+      fatal' = fatal,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  /// Bad transition: skips the next contiguous sequence.
+  action badSkippedSeqStep = {
+    nondet d = oneOf(deltaUniverse.filter(d =>
+      d.seq > followerSeq + 1
+        and d.epoch == followerEpoch
+        and d.writer == followerWriter
+    ))
+    all {
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas.union(Set(d)),
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = d.seq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = d.checksum,
+      pageCount' = d.endPageCount,
+      applied' = applied.union(Set(d)),
+      fatal' = fatal,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  /// Bad transition: accepts a delta with a broken chain link.
+  action badPrevChecksumStep = {
+    nondet d = oneOf(deltaUniverse.filter(d =>
+      d.seq == followerSeq + 1
+        and d.epoch == followerEpoch
+        and d.writer == followerWriter
+        and d.prevChecksum != chainAnchor
+    ))
+    all {
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas.union(Set(d)),
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = d.seq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = d.checksum,
+      pageCount' = d.endPageCount,
+      applied' = applied.union(Set(d)),
+      fatal' = fatal,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  /// Bad transition: creates equivocation but forgets to enter fatal mode.
+  action badEquivocationStep = {
+    nondet a = oneOf(deltaUniverse)
+    nondet b = oneOf(deltaUniverse.filter(b => divergentCandidate(a, b)))
+    all {
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas.union(Set(a, b)),
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = followerSeq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = chainAnchor,
+      pageCount' = pageCount,
+      applied' = applied,
+      fatal' = fatal,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  /// Bad transition: admits two different payload shapes with one checksum.
+  action badChecksumCollisionStep = {
+    nondet a = oneOf(deltaUniverse)
+    nondet b = oneOf(deltaUniverse.filter(b =>
+      a.checksum == b.checksum and not(samePayloadShape(a, b))
+    ))
+    all {
+      root' = root,
+      leaseEpoch' = leaseEpoch,
+      leaseHolder' = leaseHolder,
+      deltas' = deltas.union(Set(a, b)),
+      followerBaseSeq' = followerBaseSeq,
+      followerBaseChecksum' = followerBaseChecksum,
+      followerSeq' = followerSeq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = chainAnchor,
+      pageCount' = pageCount,
+      applied' = applied,
+      fatal' = fatal,
+      promoted' = promoted,
+      promotedFromSeq' = promotedFromSeq,
+      promotedFromPageCount' = promotedFromPageCount,
+      promotedFromApplied' = promotedFromApplied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  /// Bad transition: promotes a base whose cursor skips the applied prefix.
+  action badPromotionCursorStep = {
+    nondet newWriter = oneOf(writers)
+    all {
+      not(promoted),
+      root' = {
+        seq: followerSeq + 1,
+        epoch: leaseEpoch + 1,
+        writer: newWriter,
+        checksum: promotedBaseChecksum,
+        endPageCount: pageCount,
+      },
+      leaseEpoch' = leaseEpoch + 1,
+      leaseHolder' = newWriter,
+      deltas' = deltas,
+      followerBaseSeq' = followerSeq + 1,
+      followerBaseChecksum' = promotedBaseChecksum,
+      followerSeq' = followerSeq,
+      followerEpoch' = leaseEpoch + 1,
+      followerWriter' = newWriter,
+      chainAnchor' = promotedBaseChecksum,
+      pageCount' = pageCount,
+      applied' = Set(),
+      fatal' = fatal,
+      promoted' = true,
+      promotedFromSeq' = followerSeq,
+      promotedFromPageCount' = pageCount,
+      promotedFromApplied' = applied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  /// Bad transition: applies an old writer's candidate after promotion.
+  action badStaleWriterAfterPromotionStep = {
+    nondet newWriter = oneOf(writers.filter(writer => writer != initialBase.writer))
+    nondet d = oneOf(deltaUniverse.filter(d =>
+      d.seq == initialBase.seq + 1
+        and d.epoch == initialBase.epoch
+        and d.writer == initialBase.writer
+        and d.prevChecksum == initialBase.checksum
+    ))
+    all {
+      root' = {
+        seq: initialBase.seq,
+        epoch: initialBase.epoch + 1,
+        writer: newWriter,
+        checksum: promotedBaseChecksum,
+        endPageCount: initialBase.endPageCount,
+      },
+      leaseEpoch' = initialBase.epoch + 1,
+      leaseHolder' = newWriter,
+      deltas' = Set(d),
+      followerBaseSeq' = initialBase.seq,
+      followerBaseChecksum' = promotedBaseChecksum,
+      followerSeq' = d.seq,
+      followerEpoch' = initialBase.epoch + 1,
+      followerWriter' = newWriter,
+      chainAnchor' = d.checksum,
+      pageCount' = d.endPageCount,
+      applied' = Set(d),
+      fatal' = fatal,
+      promoted' = true,
+      promotedFromSeq' = initialBase.seq,
+      promotedFromPageCount' = initialBase.endPageCount,
+      promotedFromApplied' = Set(),
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+
+  /// Bad transition: promotes a base with the right cursor but wrong page count.
+  action badPromotionPageCountStep = {
+    nondet newWriter = oneOf(writers)
+    nondet wrongPageCount = oneOf(pageCounts.filter(pc => pc != pageCount))
+    all {
+      not(promoted),
+      root' = {
+        seq: followerSeq,
+        epoch: leaseEpoch + 1,
+        writer: newWriter,
+        checksum: promotedBaseChecksum,
+        endPageCount: wrongPageCount,
+      },
+      leaseEpoch' = leaseEpoch + 1,
+      leaseHolder' = newWriter,
+      deltas' = deltas,
+      followerBaseSeq' = followerSeq,
+      followerBaseChecksum' = promotedBaseChecksum,
+      followerSeq' = followerSeq,
+      followerEpoch' = leaseEpoch + 1,
+      followerWriter' = newWriter,
+      chainAnchor' = promotedBaseChecksum,
+      pageCount' = pageCount,
+      applied' = Set(),
+      fatal' = fatal,
+      promoted' = true,
+      promotedFromSeq' = followerSeq,
+      promotedFromPageCount' = pageCount,
+      promotedFromApplied' = applied,
+      progressSeeded' = progressSeeded,
+      progressTicks' = progressTicks,
+    }
+  }
+}

--- a/specs/cursor_chain_liveness.qnt
+++ b/specs/cursor_chain_liveness.qnt
@@ -1,0 +1,177 @@
+module cursor_chain_liveness {
+  type Writer = str
+  type Checksum = str
+
+  type Delta = {
+    seq: int,
+    epoch: int,
+    writer: Writer,
+    prevChecksum: Checksum,
+    checksum: Checksum,
+    payloadFingerprint: Checksum,
+    endPageCount: int,
+  }
+
+  pure val stableEpoch: int = 0
+  pure val stableWriter: Writer = "A"
+  pure val baseChecksum: Checksum = "base0"
+  pure val targetSeq: int = 3
+
+  pure val delta1: Delta = {
+    seq: 1,
+    epoch: stableEpoch,
+    writer: stableWriter,
+    prevChecksum: baseChecksum,
+    checksum: "d1",
+    payloadFingerprint: "p1",
+    endPageCount: 1,
+  }
+
+  pure val delta2: Delta = {
+    seq: 2,
+    epoch: stableEpoch,
+    writer: stableWriter,
+    prevChecksum: "d1",
+    checksum: "d2",
+    payloadFingerprint: "p2",
+    endPageCount: 2,
+  }
+
+  pure val delta3: Delta = {
+    seq: 3,
+    epoch: stableEpoch,
+    writer: stableWriter,
+    prevChecksum: "d2",
+    checksum: "d3",
+    payloadFingerprint: "p3",
+    endPageCount: 1,
+  }
+
+  pure val stablePrefix: Set[Delta] = Set(delta1, delta2, delta3)
+
+  var deltas: Set[Delta]
+  var followerSeq: int
+  var followerEpoch: int
+  var followerWriter: Writer
+  var chainAnchor: Checksum
+  var pageCount: int
+  var applied: Set[Delta]
+  var fatal: bool
+
+  action init = all {
+    deltas' = stablePrefix,
+    followerSeq' = 0,
+    followerEpoch' = stableEpoch,
+    followerWriter' = stableWriter,
+    chainAnchor' = baseChecksum,
+    pageCount' = 0,
+    applied' = Set(),
+    fatal' = false,
+  }
+
+  action pollNoop = all {
+    deltas' = deltas,
+    followerSeq' = followerSeq,
+    followerEpoch' = followerEpoch,
+    followerWriter' = followerWriter,
+    chainAnchor' = chainAnchor,
+    pageCount' = pageCount,
+    applied' = applied,
+    fatal' = fatal,
+  }
+
+  action applyNext = {
+    nondet d = oneOf(deltas.filter(d =>
+      d.seq == followerSeq + 1
+        and d.epoch == followerEpoch
+        and d.writer == followerWriter
+        and d.prevChecksum == chainAnchor
+    ))
+    all {
+      not(fatal),
+      followerSeq < targetSeq,
+      deltas' = deltas,
+      followerSeq' = d.seq,
+      followerEpoch' = followerEpoch,
+      followerWriter' = followerWriter,
+      chainAnchor' = d.checksum,
+      pageCount' = d.endPageCount,
+      applied' = applied.union(Set(d)),
+      fatal' = fatal,
+    }
+  }
+
+  /// Stable-prefix follower polling relation for this liveness slice: a poll
+  /// can observe no new progress, or it can apply the next available delta.
+  /// Root publishing, writer churn, object-store discovery, and fatal
+  /// equivocation are modeled in `cursor_chain.qnt`, not in this temporal slice.
+  action step = any {
+    applyNext,
+    pollNoop,
+  }
+
+  def appliedHasSeq(seq: int): bool =
+    applied.exists(d => d.seq == seq)
+
+  def stableEnvironment: bool =
+    deltas == stablePrefix
+      and followerEpoch == stableEpoch
+      and followerWriter == stableWriter
+      and not(fatal)
+
+  def prefixCaughtUp: bool =
+    followerSeq == targetSeq
+
+  def stablePrefixAvailable: bool =
+    stableEnvironment
+      and deltas.contains(delta1)
+      and deltas.contains(delta2)
+      and deltas.contains(delta3)
+
+  def contiguousApplied: bool =
+    1.to(targetSeq).forall(seq => seq > followerSeq or appliedHasSeq(seq))
+
+  def appliedMatchesFence: bool =
+    applied.forall(d => d.epoch == followerEpoch and d.writer == followerWriter)
+
+  def appliedChainsFromBase: bool =
+    applied.forall(d =>
+      if (d.seq == 1) {
+        d.prevChecksum == baseChecksum
+      } else {
+        applied.exists(prev =>
+          prev.seq == d.seq - 1 and d.prevChecksum == prev.checksum
+        )
+      }
+    )
+
+  def safety: bool = and {
+    followerSeq >= 0,
+    followerSeq <= targetSeq,
+    contiguousApplied,
+    appliedMatchesFence,
+    appliedChainsFromBase,
+  }
+
+  val livenessVars = (
+    deltas,
+    followerSeq,
+    followerEpoch,
+    followerWriter,
+    chainAnchor,
+    pageCount,
+    applied,
+    fatal,
+  )
+
+  /// If a valid prefix remains available in a stable environment, weak
+  /// fairness of `applyNext` rules out polling forever without applying it.
+  temporal fairStablePrefixProgress =
+    applyNext.weakFair(livenessVars)
+      implies (stablePrefixAvailable leadsTo prefixCaughtUp)
+
+  /// Expected to fail: without fairness, a follower can poll forever without
+  /// taking `applyNext`, even though the prefix remains available.
+  temporal badUnfairPollingProgress =
+    stablePrefixAvailable leadsTo prefixCaughtUp
+}

--- a/src/tiered/manifest.rs
+++ b/src/tiered/manifest.rs
@@ -13,19 +13,19 @@ pub struct Manifest {
     /// Monotonically increasing version (bumped +1 on each checkpoint).
     /// Used for S3 key uniqueness: `pg/{gid}_v{version}`.
     pub version: u64,
-    /// Pre-phase-004 replay floor (the SQLite change-counter-based cutoff).
+    /// Legacy replay floor (the SQLite change-counter-based cutoff).
     ///
     /// Checkpoint/import paths initialize this from SQLite's file change counter
     /// (page 0, offset 24). Direct page replay may advance it to the latest
     /// committed changeset sequence even when the SQLite header counter is lower.
     ///
-    /// **Phase 004 supersedes this field as the replay floor.** Followers
+    /// **Replay cursor supersedes this field as the replay floor.** Followers
     /// must use `cursor.last_applied_seq` (see [`ReplayCursor`]) — the
     /// SQLite header change counter is explicitly not load-bearing for
-    /// phase-004 replay. `change_counter` is kept here for the step 1→4
-    /// transition so existing flush / handle paths continue to set it
-    /// alongside `cursor`; the field will be removed once every consumer
-    /// reads from the cursor instead.
+    /// cursor-chain replay. `change_counter` is kept for compatibility while
+    /// existing flush / handle paths continue to set it alongside `cursor`;
+    /// the field will be removed once every consumer reads from the cursor
+    /// instead.
     ///
     /// Default 0 for backward compat (delta replay starts from the beginning).
     #[serde(default)]
@@ -106,7 +106,7 @@ pub struct Manifest {
     /// without fetching from S3 or reopening the connection.
     /// None for manifests created before this field was added.
     ///
-    /// Phase Strata note: this field intentionally has no `skip_serializing_if`.
+    /// Serialization note: this field intentionally has no `skip_serializing_if`.
     /// Under rmp_serde's positional encoding, a conditionally-skipped field in
     /// the middle of the struct shifts every subsequent field's array index,
     /// which breaks deserialization whenever a new field is added after it.
@@ -121,17 +121,17 @@ pub struct Manifest {
     /// `discontinuity_stamp` differs from their cached manifest's stamp
     /// treat their local cache as stale and cold-start from the remote.
     ///
-    /// Renamed from `epoch` in phase 004 to disambiguate from
-    /// `ReplayCursor.epoch` (the lease-holder epoch).
+    /// Renamed from `epoch` to disambiguate from `ReplayCursor.epoch` (the
+    /// lease-holder epoch).
     ///
-    /// Placed before the cursor/writer_id additions so pre-phase-004
-    /// manifest bytes still decode this slot cleanly (missing trailing
-    /// elements → serde default fills `discontinuity_stamp = 0`).
+    /// Placed before the cursor/writer_id additions so legacy manifest bytes
+    /// still decode this slot cleanly (missing trailing elements → serde
+    /// default fills `discontinuity_stamp = 0`).
     #[serde(default, alias = "epoch")]
     pub discontinuity_stamp: u64,
 
     /// Durable replay cursor — the authoritative replay floor for
-    /// followers in phase 004 substrate replay.
+    /// cursor-chain substrate replay.
     ///
     /// `cursor.last_applied_seq` is the seq up to which deltas have been
     /// folded into this base. Followers replay delta objects with
@@ -155,13 +155,13 @@ pub struct Manifest {
     /// Identifier of the lease holder that published this base manifest.
     /// Followers filter delta candidates against this writer_id; deltas
     /// stamped with a different writer_id are dropped before chain
-    /// verification. Empty string for pre-phase-004 / bootstrap manifests
+    /// verification. Empty string for legacy / bootstrap manifests
     /// where fencing is not yet established.
     #[serde(default)]
     pub writer_id: String,
 }
 
-/// Durable replay cursor for phase 004 substrate replay.
+/// Durable replay cursor for cursor-chain substrate replay.
 ///
 /// Followers persist this after each successful atomic apply. The cursor
 /// is the only authoritative replay floor — the SQLite header change

--- a/src/tiered/replay.rs
+++ b/src/tiered/replay.rs
@@ -1048,11 +1048,15 @@ mod tests {
 
         assert_eq!(vfs.manifest().change_counter, seq);
 
-        let bytes = vfs
-            .publish_replayed_base()
-            .expect("publish replayed base after cursor promotion");
+        let (bytes, anchor) = vfs
+            .publish_replayed_base_with_replay_cursor_anchor(seq, 1, "cursor-writer")
+            .expect("publish anchored replayed base after cursor promotion");
         let published = TurboliteVfs::decode_manifest_bytes(&bytes).unwrap();
         assert_eq!(published.change_counter, seq);
+        assert_eq!(published.cursor.last_applied_seq, seq);
+        assert_eq!(published.cursor.epoch, 1);
+        assert_eq!(published.writer_id, "cursor-writer");
+        assert_eq!(published.cursor.base_object_checksum, anchor);
     }
 
     /// Two replay cycles back-to-back without an intervening publish
@@ -2562,6 +2566,7 @@ mod tests {
 
     /// `publish_replayed_base` returns pure page/base manifest bytes.
     #[test]
+    #[allow(deprecated)]
     fn publish_replayed_base_round_trips_pure_manifest_when_no_pending_state() {
         let tmp = TempDir::new().unwrap();
         let (vfs, _page_size) = fresh_vfs_with_pages(&tmp, 4);
@@ -2576,25 +2581,27 @@ mod tests {
         );
     }
 
-    /// `publish_replayed_base` after a successful replay returns a
-    /// manifest whose page_group_keys reflect the flushed groups.
+    /// Anchored replay cursor publish after a successful replay returns a manifest
+    /// whose page_group_keys reflect the flushed groups and whose cursor
+    /// anchors the final post-replay base.
     /// The check that the keys differ from the pre-replay manifest
     /// for every replayed group is encoded by the flush primitive,
     /// not by this test directly; here we assert the simpler shape
     /// invariant: the published manifest version >= the post-finalize
     /// manifest version, and page_count covers the replayed pages.
     #[test]
-    fn publish_replayed_base_after_replay_carries_post_replay_state() {
+    fn replay_cursor_contract_publish_replayed_base_after_replay_carries_post_replay_state() {
         let tmp = TempDir::new().unwrap();
         let (vfs, page_size) = fresh_vfs_with_pages(&tmp, 4);
         let cache = vfs_cache(&vfs);
         let pre_replay = vec![0xAAu8; page_size as usize];
         cache.write_page(0, &pre_replay).unwrap();
+        let replay_seq = vfs.manifest().change_counter + 1;
 
         let new_bytes = vec![0xBBu8; page_size as usize];
-        let mut handle = vfs.begin_replay_after(6).unwrap();
+        let mut handle = vfs.begin_replay_after(replay_seq - 1).unwrap();
         handle.apply_page(1, &new_bytes).unwrap();
-        handle.commit_changeset(7).unwrap();
+        handle.commit_changeset(replay_seq).unwrap();
         handle.finalize().unwrap();
 
         let post_finalize_version = vfs.manifest().version;
@@ -2602,14 +2609,29 @@ mod tests {
         // The local-mode VFS keeps no remote storage, so flush is a
         // no-op upload-wise but still bumps the manifest. Tests for
         // remote-mode flush behaviour live in flush.rs's own suite.
-        let bytes = vfs
-            .publish_replayed_base()
-            .expect("publish_replayed_base after replay");
+        let (bytes, anchor) = vfs
+            .publish_replayed_base_with_replay_cursor_anchor(replay_seq, 12, "writer-after-replay")
+            .expect("anchored publish_replayed_base after replay");
         let m = TurboliteVfs::decode_manifest_bytes(&bytes).unwrap();
         assert!(
             m.version >= post_finalize_version,
             "published manifest version must be >= post-finalize version (post={post_finalize_version}, published={})",
             m.version
+        );
+        assert!(
+            m.change_counter >= replay_seq,
+            "legacy change_counter must not move behind the replay sequence"
+        );
+        assert_eq!(m.cursor.last_applied_seq, replay_seq);
+        assert_eq!(m.cursor.epoch, 12);
+        assert_eq!(m.writer_id, "writer-after-replay");
+        assert_eq!(m.cursor.base_object_checksum, anchor);
+        assert_eq!(
+            crate::tiered::wire::base_anchor_checksum(&m)
+                .expect("recompute post-replay anchor")
+                .to_vec(),
+            anchor,
+            "anchored publish must bind the manifest after replay finalize and flush"
         );
     }
 }

--- a/src/tiered/sashimono.rs
+++ b/src/tiered/sashimono.rs
@@ -815,6 +815,79 @@ mod tests {
     }
 
     #[test]
+    fn replay_cursor_contract_recovery_plan_applies_contiguous_prefix_and_page_counts() {
+        let checkpoint = checkpoint_fixture();
+        let delta1 = delta_fixture();
+
+        let mut delta2 = delta_fixture();
+        delta2.sequence = 2;
+        delta2.base_database_version = delta1.end_database_version;
+        delta2.end_database_version = 3;
+        delta2.base_database_page_count = delta1.end_database_page_count;
+        delta2.end_database_page_count = 4;
+        delta2.changed_pages[0].page_number = 3;
+        delta2.replay_idempotency_key = "replay-0002".to_string();
+        delta2.checksum = delta2.fixture_checksum();
+
+        let mut delta3 = delta_fixture();
+        delta3.sequence = 3;
+        delta3.base_database_version = delta2.end_database_version;
+        delta3.end_database_version = 4;
+        delta3.base_database_page_count = delta2.end_database_page_count;
+        delta3.end_database_page_count = 2;
+        delta3.changed_pages[0].page_number = 1;
+        delta3.changed_pages[1].page_number = 0;
+        delta3.replay_idempotency_key = "replay-0003".to_string();
+        delta3.checksum = delta3.fixture_checksum();
+
+        let mut root = root_fixture();
+        root.latest_delta_sequence = 3;
+        root.latest_database_version = 4;
+
+        let plan = select_recovery_plan(
+            &root,
+            &[checkpoint.clone()],
+            &[delta1.clone(), delta2.clone(), delta3.clone()],
+            128,
+        )
+        .expect("contiguous three-delta prefix should plan");
+
+        assert_eq!(plan.checkpoint.checkpoint_delta_sequence, 0);
+        assert_eq!(
+            plan.checkpoint.database_page_count,
+            checkpoint.database_page_count
+        );
+        assert_eq!(
+            plan.deltas
+                .iter()
+                .map(|delta| (
+                    delta.sequence,
+                    delta.base_database_page_count,
+                    delta.end_database_page_count,
+                ))
+                .collect::<Vec<_>>(),
+            vec![(1, 2, 3), (2, 3, 4), (3, 4, 2)]
+        );
+    }
+
+    #[test]
+    fn replay_cursor_contract_recovery_plan_rejects_stale_epoch_candidate() {
+        let mut root = root_fixture();
+        root.latest_delta_sequence = 1;
+        root.latest_database_version = 2;
+
+        let checkpoint = checkpoint_fixture();
+        let mut stale = delta_fixture();
+        stale.lease_epoch -= 1;
+        stale.checksum = stale.fixture_checksum();
+
+        let err = select_recovery_plan(&root, &[checkpoint], &[stale], 128)
+            .expect_err("stale epoch candidate must not satisfy the root fence");
+
+        assert_eq!(err, ContractError::MissingDelta(1));
+    }
+
+    #[test]
     fn root_update_rejects_rollback() {
         let previous = root_fixture();
         let mut next = previous.clone();

--- a/src/tiered/test_local_vfs.rs
+++ b/src/tiered/test_local_vfs.rs
@@ -279,6 +279,233 @@ fn exact_replay_cursor_can_replace_sqlite_header_counter() {
     );
 }
 
+#[test]
+fn replay_cursor_contract_manifest_bytes_stamps_cursor_writer_and_anchor() {
+    let dir = TempDir::new().unwrap();
+    let config = TurboliteConfig {
+        cache_dir: dir.path().to_path_buf(),
+        ..Default::default()
+    };
+    let vfs = TurboliteVfs::new_local(config).expect("local VFS");
+
+    let mut base = Manifest::empty();
+    base.version = 7;
+    base.change_counter = 99;
+    base.page_count = 4;
+    vfs.set_manifest(base);
+
+    let (bytes, anchor) = vfs
+        .manifest_bytes_with_replay_cursor_anchor(3, 11, "writer-a")
+        .expect("anchored replay cursor manifest bytes");
+    let decoded = TurboliteVfs::decode_manifest_bytes(&bytes).expect("decode replay cursor bytes");
+
+    assert_eq!(decoded.cursor.last_applied_seq, 3);
+    assert_eq!(
+        decoded.change_counter, 3,
+        "legacy replay floor must track the exact anchored cursor until every consumer is cursor-native"
+    );
+    assert_eq!(decoded.cursor.epoch, 11);
+    assert_eq!(decoded.writer_id, "writer-a");
+    assert_eq!(decoded.cursor.base_object_checksum, anchor);
+    assert_eq!(
+        super::wire::base_anchor_checksum(&decoded)
+            .expect("recompute base anchor")
+            .to_vec(),
+        anchor,
+        "publisher and follower must agree on the first-delta chain anchor"
+    );
+    assert_eq!(
+        vfs.manifest().cursor,
+        decoded.cursor,
+        "anchored replay cursor publication must update the installed manifest"
+    );
+    assert_eq!(
+        vfs.manifest().change_counter,
+        3,
+        "installed compatibility cursor must match the published anchored cursor"
+    );
+}
+
+#[test]
+fn replay_cursor_contract_begin_replay_uses_installed_cursor_floor() {
+    let dir = TempDir::new().unwrap();
+    let config = TurboliteConfig {
+        cache_dir: dir.path().to_path_buf(),
+        ..Default::default()
+    };
+    let vfs = TurboliteVfs::new_local(config).expect("local VFS");
+
+    let mut base = Manifest::empty();
+    base.version = 7;
+    base.page_size = 4096;
+    base.page_count = 4;
+    vfs.set_manifest(base);
+    vfs.manifest_bytes_with_replay_cursor_anchor(3, 11, "writer-a")
+        .expect("seed anchored cursor");
+
+    let mut replay = vfs.begin_replay().expect("begin replay after cursor");
+    let err = replay
+        .commit_changeset(3)
+        .expect_err("begin_replay must not accept an already-folded sequence");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    replay
+        .commit_changeset(4)
+        .expect("begin_replay should resume after the installed replay cursor");
+    replay.abort().expect("abort test replay");
+}
+
+#[test]
+fn replay_cursor_contract_manifest_bytes_rejects_invalid_cursor_inputs() {
+    let dir = TempDir::new().unwrap();
+    let config = TurboliteConfig {
+        cache_dir: dir.path().to_path_buf(),
+        ..Default::default()
+    };
+    let vfs = TurboliteVfs::new_local(config).expect("local VFS");
+
+    let mut base = Manifest::empty();
+    base.version = 7;
+    base.page_count = 4;
+    vfs.set_manifest(base);
+
+    let err = vfs
+        .manifest_bytes_with_replay_cursor_anchor(3, 0, "writer-a")
+        .expect_err("zero cursor publish epoch must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    let err = vfs
+        .manifest_bytes_with_replay_cursor_anchor(3, 11, "   ")
+        .expect_err("blank cursor writer must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    vfs.manifest_bytes_with_replay_cursor_anchor(3, 11, "writer-a")
+        .expect("seed valid anchored cursor");
+
+    let err = vfs
+        .manifest_bytes_with_replay_cursor_anchor(2, 12, "writer-b")
+        .expect_err("published cursor must not move backward");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn replay_cursor_contract_update_replay_cursor_preserves_base_shape_and_writer() {
+    let dir = TempDir::new().unwrap();
+    let config = TurboliteConfig {
+        cache_dir: dir.path().to_path_buf(),
+        ..Default::default()
+    };
+    let vfs = TurboliteVfs::new_local(config).expect("local VFS");
+
+    let mut base = Manifest::empty();
+    base.version = 9;
+    base.page_count = 6;
+    vfs.set_manifest(base);
+    vfs.manifest_bytes_with_replay_cursor_anchor(3, 11, "writer-a")
+        .expect("seed anchored cursor");
+
+    let before = vfs.manifest();
+    let next_cursor = ReplayCursor {
+        last_applied_seq: 4,
+        base_object_checksum: vec![0xAB; 32],
+        epoch: 11,
+    };
+    vfs.update_replay_cursor(next_cursor.clone())
+        .expect("advance replay cursor");
+    let after = vfs.manifest();
+
+    assert_eq!(after.cursor, next_cursor);
+    assert_eq!(after.writer_id, "writer-a");
+    assert_eq!(after.version, before.version);
+    assert_eq!(after.page_count, before.page_count);
+    assert_eq!(after.page_group_keys, before.page_group_keys);
+}
+
+#[test]
+fn replay_cursor_contract_update_replay_cursor_rejects_malformed_or_backward_cursor() {
+    let dir = TempDir::new().unwrap();
+    let config = TurboliteConfig {
+        cache_dir: dir.path().to_path_buf(),
+        ..Default::default()
+    };
+    let vfs = TurboliteVfs::new_local(config).expect("local VFS");
+
+    let mut base = Manifest::empty();
+    base.version = 9;
+    base.page_count = 6;
+    vfs.set_manifest(base);
+
+    let err = vfs
+        .update_replay_cursor(ReplayCursor {
+            last_applied_seq: 1,
+            base_object_checksum: vec![0xAB; 32],
+            epoch: 11,
+        })
+        .expect_err("advanced cursor requires installed writer id");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    vfs.manifest_bytes_with_replay_cursor_anchor(3, 11, "writer-a")
+        .expect("seed anchored cursor");
+
+    let err = vfs
+        .update_replay_cursor(ReplayCursor {
+            last_applied_seq: 4,
+            base_object_checksum: vec![0xAB; 31],
+            epoch: 11,
+        })
+        .expect_err("advanced cursor requires a 32-byte anchor");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    let err = vfs
+        .update_replay_cursor(ReplayCursor {
+            last_applied_seq: 2,
+            base_object_checksum: vec![0xAB; 32],
+            epoch: 11,
+        })
+        .expect_err("follower cursor must not move backward");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn replay_cursor_contract_publish_replayed_base_stamps_final_cursor_anchor() {
+    let dir = TempDir::new().unwrap();
+    let config = TurboliteConfig {
+        cache_dir: dir.path().to_path_buf(),
+        ..Default::default()
+    };
+    let vfs = TurboliteVfs::new_local(config).expect("local VFS");
+
+    let mut base = Manifest::empty();
+    base.version = 13;
+    base.page_count = 8;
+    base.page_group_keys = vec!["base-group-0".to_string(), "base-group-1".to_string()];
+    vfs.set_manifest(base);
+
+    vfs.manifest_bytes_with_replay_cursor_anchor(4, 10, "writer-a")
+        .expect("seed working replay cursor");
+
+    let before_publish = vfs.manifest();
+    let (bytes, anchor) = vfs
+        .publish_replayed_base_with_replay_cursor_anchor(5, 12, "writer-b")
+        .expect("anchored replayed base");
+    let decoded = TurboliteVfs::decode_manifest_bytes(&bytes).expect("decode promoted base");
+
+    assert_eq!(decoded.cursor.last_applied_seq, 5);
+    assert_eq!(decoded.cursor.epoch, 12);
+    assert_eq!(decoded.writer_id, "writer-b");
+    assert_eq!(decoded.cursor.base_object_checksum, anchor);
+    assert_eq!(
+        super::wire::base_anchor_checksum(&decoded)
+            .expect("recompute promoted base anchor")
+            .to_vec(),
+        anchor,
+        "promotion must anchor the final published base, not the stale working cursor"
+    );
+    assert_eq!(decoded.version, before_publish.version);
+    assert_eq!(decoded.page_count, before_publish.page_count);
+    assert_eq!(decoded.page_group_keys, before_publish.page_group_keys);
+    assert_eq!(vfs.manifest().cursor, decoded.cursor);
+}
+
 /// Local VFS with compression enabled: write + checkpoint + reopen.
 #[test]
 #[cfg(feature = "zstd")]

--- a/src/tiered/vfs.rs
+++ b/src/tiered/vfs.rs
@@ -85,6 +85,78 @@ pub struct TurboliteVfs {
     wal_state: std::sync::Mutex<wal_replication::WalReplicationState>,
 }
 
+fn invalid_replay_cursor_anchor(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn validate_replay_cursor_anchor(field: &str, anchor: &[u8]) -> io::Result<()> {
+    if !anchor.is_empty() && anchor.len() != 32 {
+        return Err(invalid_replay_cursor_anchor(format!(
+            "{field} must be empty for bootstrap or exactly 32 bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_replay_cursor_update(
+    manifest: &Manifest,
+    cursor: &super::manifest::ReplayCursor,
+) -> io::Result<()> {
+    if cursor.last_applied_seq < manifest.cursor.last_applied_seq {
+        return Err(invalid_replay_cursor_anchor(format!(
+            "replay cursor cannot move backward from {} to {}",
+            manifest.cursor.last_applied_seq, cursor.last_applied_seq
+        )));
+    }
+    validate_replay_cursor_anchor(
+        "replay cursor base_object_checksum",
+        &cursor.base_object_checksum,
+    )?;
+    if cursor.last_applied_seq > 0 {
+        if cursor.base_object_checksum.len() != 32 {
+            return Err(invalid_replay_cursor_anchor(
+                "advanced replay cursor requires a 32-byte base_object_checksum",
+            ));
+        }
+        if cursor.epoch == 0 {
+            return Err(invalid_replay_cursor_anchor(
+                "advanced replay cursor requires nonzero lease epoch",
+            ));
+        }
+        if manifest.writer_id.trim().is_empty() {
+            return Err(invalid_replay_cursor_anchor(
+                "advanced replay cursor requires an installed writer_id",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_replay_cursor_publish(
+    manifest: &Manifest,
+    last_applied_seq: u64,
+    epoch: u64,
+    writer_id: &str,
+) -> io::Result<()> {
+    if last_applied_seq < manifest.cursor.last_applied_seq {
+        return Err(invalid_replay_cursor_anchor(format!(
+            "published replay cursor cannot move backward from {} to {}",
+            manifest.cursor.last_applied_seq, last_applied_seq
+        )));
+    }
+    if epoch == 0 {
+        return Err(invalid_replay_cursor_anchor(
+            "anchored replay cursor publish requires nonzero lease epoch",
+        ));
+    }
+    if writer_id.trim().is_empty() {
+        return Err(invalid_replay_cursor_anchor(
+            "anchored replay cursor publish requires nonempty writer_id",
+        ));
+    }
+    Ok(())
+}
+
 impl TurboliteVfs {
     /// Local mode. Wraps `hadb_storage_local::LocalStorage` rooted at
     /// `config.cache_dir` and spins up a dedicated 2-thread tokio runtime.
@@ -945,13 +1017,12 @@ impl TurboliteVfs {
         super::wire::encode(&m).map_err(io::Error::from)
     }
 
-    /// Phase 004: persist the follower's advancing **working** replay
-    /// cursor.
+    /// Persist the follower's advancing working replay cursor.
     ///
     /// After a follower applies a verified prefix of delta envelopes, it
     /// records its new replay position here: `last_applied_seq` and the
     /// `base_object_checksum` anchor advance to the last applied delta's
-    /// envelope checksum (see `phase4_chain::FollowerCursor`). This is
+    /// envelope checksum. This is
     /// stored in the local manifest's `cursor` field so the next poll —
     /// and a process restart — resume from the right anchor instead of
     /// re-applying from the base.
@@ -961,37 +1032,25 @@ impl TurboliteVfs {
     /// the local cache, not new groups) is left intact.
     pub fn update_replay_cursor(&self, cursor: super::manifest::ReplayCursor) -> io::Result<()> {
         let mut m = self.manifest();
+        validate_replay_cursor_update(&m, &cursor)?;
         m.cursor = cursor;
         manifest::persist_manifest_local(&self.cache.cache_dir, &m)?;
         self.shared_manifest.store(Arc::new(m));
         Ok(())
     }
 
-    /// Phase 004 base publish: stamp the manifest with a populated
-    /// replay cursor and writer identity, then encode it.
-    ///
-    /// Sets `cursor.last_applied_seq`, `cursor.epoch`, and `writer_id`,
-    /// computes the chain anchor via [`super::wire::base_anchor_checksum`]
-    /// (BLAKE3 of the manifest with the anchor field cleared), writes
-    /// that anchor into `cursor.base_object_checksum`, persists locally,
-    /// installs the shared manifest, and returns `(payload, anchor)`.
-    ///
-    /// The caller publishes `payload` through the ManifestStore and uses
-    /// `anchor` as the `prev_checksum` of the first delta after this
-    /// base. A follower decoding the payload reads the same anchor from
-    /// `cursor.base_object_checksum` and verifies the first delta
-    /// chains to it. This is the writer half of the phase-004 contract;
-    /// `update_replay_cursor` is the follower half.
-    pub fn manifest_bytes_with_phase4_cursor(
+    fn manifest_bytes_with_installed_replay_cursor_anchor(
         &self,
         last_applied_seq: u64,
         epoch: u64,
         writer_id: &str,
     ) -> io::Result<(Vec<u8>, Vec<u8>)> {
         let mut m = self.manifest();
+        validate_replay_cursor_publish(&m, last_applied_seq, epoch, writer_id)?;
         m.cursor.last_applied_seq = last_applied_seq;
         m.cursor.epoch = epoch;
         m.writer_id = writer_id.to_string();
+        m.change_counter = last_applied_seq;
         // Anchor is hashed with the field cleared (base_anchor_checksum
         // does the clearing); then we store it back so the follower
         // reads it directly.
@@ -1001,6 +1060,32 @@ impl TurboliteVfs {
         self.shared_manifest.store(Arc::new(m.clone()));
         let payload = super::wire::encode(&m).map_err(io::Error::from)?;
         Ok((payload, anchor.to_vec()))
+    }
+
+    /// Anchored replay cursor base publish: stamp the manifest with a populated
+    /// replay cursor and writer identity, then encode it.
+    ///
+    /// Sets `cursor.last_applied_seq`, `cursor.epoch`, and `writer_id`,
+    /// sets the legacy `change_counter` compatibility field to the same
+    /// exact replay floor,
+    /// computes the chain anchor via [`super::wire::base_anchor_checksum`]
+    /// (BLAKE3 of the manifest with the anchor field cleared), writes
+    /// that anchor into `cursor.base_object_checksum`, persists locally,
+    /// installs the shared manifest, and returns `(payload, anchor)`.
+    ///
+    /// The caller publishes `payload` through the ManifestStore and uses
+    /// `anchor` as the `prev_checksum` of the first delta after this
+    /// base. A follower decoding the payload reads the same anchor from
+    /// `cursor.base_object_checksum` and verifies the first delta
+    /// chains to it. This is the writer half of the replay cursor contract;
+    /// `update_replay_cursor` is the follower half.
+    pub fn manifest_bytes_with_replay_cursor_anchor(
+        &self,
+        last_applied_seq: u64,
+        epoch: u64,
+        writer_id: &str,
+    ) -> io::Result<(Vec<u8>, Vec<u8>)> {
+        self.manifest_bytes_with_installed_replay_cursor_anchor(last_applied_seq, epoch, writer_id)
     }
 
     /// Decode wire bytes produced by `manifest_bytes` and apply the resulting
@@ -1293,7 +1378,13 @@ impl TurboliteVfs {
     ///
     /// See `crate::tiered::replay` for the full lifecycle contract.
     pub fn begin_replay(&self) -> io::Result<crate::tiered::replay::ReplayHandle> {
-        self.begin_replay_after(self.manifest().change_counter)
+        let manifest = self.manifest();
+        self.begin_replay_after(
+            manifest
+                .cursor
+                .last_applied_seq
+                .max(manifest.change_counter),
+        )
     }
 
     /// Begin a direct page replay cycle after a known durable replay cursor.
@@ -1350,6 +1441,11 @@ impl TurboliteVfs {
     /// manifest key. If no replay state is pending, the call still
     /// returns the current pure manifest payload — that covers the
     /// "follower already caught up before promotion" case.
+    ///
+    /// Anchored replay cursor promotion callers should use
+    /// [`Self::publish_replayed_base_with_replay_cursor_anchor`] so the published
+    /// base carries the authoritative replay cursor and chain anchor.
+    #[deprecated(note = "anchored replay cursor promotion must use publish_replayed_base_with_replay_cursor_anchor")]
     pub fn publish_replayed_base(&self) -> io::Result<Vec<u8>> {
         // Drive a flush over any pending replay state. flush_to_storage
         // drains pending_flushes + shared_dirty_groups together and
@@ -1363,6 +1459,24 @@ impl TurboliteVfs {
         // discoverable from the integration layer's configured delta
         // storage, not encoded into the page/base manifest.
         self.manifest_bytes()
+    }
+
+    /// Promote accumulated replayed state to an anchored replay cursor remote
+    /// manifest payload.
+    ///
+    /// This is the composed promotion path: first drain pending replay state
+    /// into the base manifest, then stamp the final manifest with the replay
+    /// cursor, lease epoch, writer id, and freshly-computed base chain anchor.
+    /// The returned anchor is the `prev_checksum` expected on the first delta
+    /// after this promoted base.
+    pub fn publish_replayed_base_with_replay_cursor_anchor(
+        &self,
+        last_applied_seq: u64,
+        epoch: u64,
+        writer_id: &str,
+    ) -> io::Result<(Vec<u8>, Vec<u8>)> {
+        self.flush_to_storage()?;
+        self.manifest_bytes_with_installed_replay_cursor_anchor(last_applied_seq, epoch, writer_id)
     }
 
     /// Handle setup for the sqlite-plugin `Vfs::open`. `is_main_db` picks the

--- a/src/tiered/wire.rs
+++ b/src/tiered/wire.rs
@@ -1,4 +1,4 @@
-//! Turbolite manifest wire format — phase 004 canonical CBOR envelope.
+//! Turbolite manifest wire format — canonical CBOR envelope.
 //!
 //! The bytes produced by [`encode`] are what turbolite publishes through a
 //! `ManifestStore` (the envelope's opaque payload) and what
@@ -36,13 +36,12 @@
 //!
 //! ### Legacy payload rejection
 //!
-//! Pre-phase-004 wire payloads led with a one-byte tag (`0x01` = pure
+//! Legacy wire payloads led with a one-byte tag (`0x01` = pure
 //! msgpack, `0x02` = hybrid). Both are detected before the magic check
 //! and surfaced as distinct [`PayloadVersionError`] variants so a
 //! follower hitting old bytes gets an actionable error instead of a
-//! generic decode failure. The plan accepts no silent fallback; a
-//! separate migration phase can add one if real on-disk data needs
-//! converting.
+//! generic decode failure. There is no silent fallback; a migration
+//! reader can add one if real on-disk data needs converting.
 
 use std::io;
 
@@ -58,10 +57,10 @@ const MAGIC: [u8; 4] = *b"TLM1";
 /// Current canonical-CBOR envelope version.
 const VERSION_V1: u16 = 0x0001;
 
-/// Pre-phase-004 leading-tag byte: pure msgpack manifest payload.
+/// Legacy leading-tag byte: pure msgpack manifest payload.
 const TAG_LEGACY_PURE: u8 = 0x01;
 
-/// Pre-phase-004 leading-tag byte: hybrid (manifest + walrust delta cursor) payload.
+/// Legacy leading-tag byte: hybrid (manifest + walrust delta cursor) payload.
 const TAG_LEGACY_HYBRID: u8 = 0x02;
 
 /// Error surface for canonical-envelope decode.
@@ -72,20 +71,20 @@ const TAG_LEGACY_HYBRID: u8 = 0x02;
 /// version we don't support".
 #[derive(Debug, thiserror::Error)]
 pub enum PayloadVersionError {
-    /// Pre-phase-004 hybrid payload (leading byte `0x02`). The hybrid
+    /// Legacy hybrid payload (leading byte `0x02`). The hybrid
     /// payload embedded walrust delta cursor/prefix fields beside the
-    /// page manifest. Phase 004 removed it; delta discovery lives at the
+    /// page manifest. The canonical envelope keeps delta discovery at the
     /// integration layer now.
     #[error(
-        "legacy hybrid manifest payload (leading byte 0x02); no longer supported after phase 004"
+        "legacy hybrid manifest payload (leading byte 0x02); canonical envelope required"
     )]
     HybridDeprecated,
 
-    /// Pre-phase-004 pure msgpack payload (leading byte `0x01`). Decode
-    /// it with msgpack from a pre-phase-004 build if you need the
-    /// contents; phase 004 only accepts the `TLM1` canonical envelope.
+    /// Legacy pure msgpack payload (leading byte `0x01`). Decode it with
+    /// msgpack from an older build if you need the contents; current
+    /// readers accept the `TLM1` canonical envelope.
     #[error(
-        "legacy pure-msgpack manifest payload (leading byte 0x01); no longer supported after phase 004"
+        "legacy pure-msgpack manifest payload (leading byte 0x01); canonical envelope required"
     )]
     PureMsgpackDeprecated,
 
@@ -189,11 +188,10 @@ pub fn decode(bytes: &[u8]) -> Result<Manifest, PayloadVersionError> {
 /// `ReplayCursor::base_object_checksum` after publishing a base, and
 /// what every following delta's `prev_checksum` must match.
 ///
-/// Production callers come online in phase 004 step 2 (delta stamping);
-/// for step 1 this is exercised by `checksum_returns_blake3_of_envelope`
-/// so the API surface is covered even before the chain verifier
-/// consumes it. `#[allow(dead_code)]` suppresses the no-lib-callers
-/// warning until step 2 wires the publish path through.
+/// Delta stamping uses the same helper for envelope hashes. The unit test
+/// keeps the API covered even before every chain verifier path consumes it.
+/// `#[allow(dead_code)]` suppresses the no-lib-callers warning until those
+/// callers are wired through.
 #[allow(dead_code)]
 pub fn checksum(envelope_bytes: &[u8]) -> [u8; 32] {
     *blake3::hash(envelope_bytes).as_bytes()
@@ -203,7 +201,7 @@ pub fn checksum(envelope_bytes: &[u8]) -> [u8; 32] {
 /// into `cursor.base_object_checksum` and that the first delta after
 /// the base carries as its `prev_checksum`.
 ///
-/// Resolves the circular definition in the plan ("base_object_checksum
+/// Resolves the circular definition ("base_object_checksum
 /// = hash(this_manifest)"): the manifest contains the field, so it
 /// cannot hash itself directly. We compute the BLAKE3 of the TLM1
 /// envelope encoded with `cursor.base_object_checksum` **cleared**.
@@ -433,10 +431,10 @@ mod tests {
         }
     }
 
-    /// Round-trip preserves every load-bearing field, including the new
-    /// phase 004 ones (cursor, writer_id, discontinuity_stamp).
+    /// Round-trip preserves every load-bearing field, including cursor,
+    /// writer identity, and discontinuity stamp.
     #[test]
-    fn round_trip_preserves_phase_004_fields() {
+    fn round_trip_preserves_replay_cursor_fields() {
         let m = golden_fixture();
         let bytes = encode(&m).expect("encode");
         // Envelope sanity: magic + version + non-empty body.
@@ -493,8 +491,8 @@ mod tests {
         assert_eq!(b1, b1_again);
     }
 
-    /// BLAKE3 golden hash. The whole point of phase 004 is that this
-    /// number stays nailed down across releases. If this test fires,
+    /// BLAKE3 golden hash. This pins the canonical envelope hash across
+    /// releases. If this test fires,
     /// some serialization detail has shifted: either the canonical
     /// encoder changed (ciborium upgrade?), the field set on
     /// `CanonicalManifestV1` changed, or a sort key changed. Fix the
@@ -559,6 +557,37 @@ mod tests {
     }
 
     #[test]
+    fn replay_cursor_contract_base_anchor_binds_cursor_epoch_and_writer() {
+        let mut base = golden_fixture();
+        base.cursor.base_object_checksum = Vec::new();
+        let anchor = base_anchor_checksum(&base).expect("base anchor");
+
+        let mut different_epoch = base.clone();
+        different_epoch.cursor.epoch += 1;
+        assert_ne!(
+            anchor,
+            base_anchor_checksum(&different_epoch).expect("epoch anchor"),
+            "lease epoch must be in the base anchor hash domain"
+        );
+
+        let mut different_writer = base.clone();
+        different_writer.writer_id = "node-leader-B".into();
+        assert_ne!(
+            anchor,
+            base_anchor_checksum(&different_writer).expect("writer anchor"),
+            "writer id must be in the base anchor hash domain"
+        );
+
+        let mut different_seq = base;
+        different_seq.cursor.last_applied_seq += 1;
+        assert_ne!(
+            anchor,
+            base_anchor_checksum(&different_seq).expect("seq anchor"),
+            "last applied seq must be in the base anchor hash domain"
+        );
+    }
+
+    #[test]
     fn legacy_hybrid_returns_hybrid_deprecated() {
         let bytes = vec![TAG_LEGACY_HYBRID, 0xff, 0xff];
         let err = decode(&bytes).expect_err("must reject");
@@ -613,8 +642,8 @@ mod tests {
         }
     }
 
-    /// A pre-phase-004 manifest payload that *didn't* go through the
-    /// envelope (raw rmp_serde bytes from older builds) will fail with
+    /// A legacy manifest payload that *didn't* go through the envelope
+    /// (raw rmp_serde bytes from older builds) will fail with
     /// either PureMsgpackDeprecated (if leading byte is 0x81/etc. that
     /// happens to be 0x01 — unlikely) or MagicMismatch. Either way:
     /// not a silent fallback, not a generic CBOR decode error.
@@ -676,11 +705,9 @@ mod tests {
         );
     }
 
-    /// The `checksum()` helper is what step 2+ delta stamping will use
-    /// to compute `ReplayCursor::base_object_checksum`. Smoke-test it
-    /// here so we know the function is callable and BLAKE3 produces the
-    /// expected 32-byte output before chain-verification code depends
-    /// on it.
+    /// Delta stamping uses `checksum()` to compute chain anchors. This test
+    /// keeps the helper callable and pins the expected 32-byte BLAKE3 output
+    /// before chain-verification code depends on it.
     #[test]
     fn checksum_returns_blake3_of_envelope() {
         let bytes = encode(&golden_fixture()).expect("encode");

--- a/tests/tiered/crash_flush.rs
+++ b/tests/tiered/crash_flush.rs
@@ -168,7 +168,7 @@ fn run_crash_incremental(mode: TestMode) {
         &endpoint,
         mode,
         100,
-        &format!("[{}] phase4", mode.name()),
+        &format!("[{}] replay cursor", mode.name()),
     );
 }
 


### PR DESCRIPTION
## Summary
- add Quint replay-cursor safety/progress specs and Makefile targets
- add Rust replay-cursor bridge/contract tests
- harden replay cursor publishing/resume semantics in the tiered VFS
- remove planning-artifact names from the touched replay-cursor implementation surface

## Tests
- `make specs-all`
- `cargo test --features zstd,bundled-sqlite replay_cursor_contract`
- `cargo test --features zstd,bundled-sqlite tiered::wire::tests`
- `git diff --check`

## Notes
- Requires local Java/Quint/Apalache tooling for the formal spec targets.
- This is the Turbolite dependency for the haqlite replay-cursor orchestration PR.